### PR TITLE
[fe/refactor_apis] api 로직 분리

### DIFF
--- a/client/src/apis/api/loginApi.ts
+++ b/client/src/apis/api/loginApi.ts
@@ -1,0 +1,51 @@
+import { AxiosResponse } from 'axios';
+import defaultInstance from '../utils';
+// type
+import { LoginApi, Api } from '../../types/responseData';
+
+/**
+ * @param socialName 카카오나 네이버 사이트이름을 기입해준다.
+ * @param authorizationCode Oauth 사이트에서 리턴해준 코드를 기입해준다.
+ * @param state Oauth 사이트에서 리턴해준 state를 기입해준다.
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+export const postAuthInfo = async (
+	socialName: 'naver' | 'kakao',
+	authorizationCode: string,
+	state: string,
+): Promise<LoginApi> => {
+	const { data }: AxiosResponse<LoginApi> = await defaultInstance.post(
+		`/api/oauth/${socialName}`,
+		{
+			authorizationCode,
+			state,
+		},
+	);
+	return data;
+};
+
+/**
+ * @param email 서버에서 받은 email 정보를 기입한다.
+ * @param imageURL 오브젝트 스토리지에 올리고 받은 사진 위치 정보 기입 (변경 예정)
+ * @param userName 사용자 입력 닉네임 기입
+ * @param oauthInfo NAVER 혹은 KAKAO
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+// TODO 이미지 url 을 보내는 것이 아닌 form 으로 사진 데이터를 보내야한다.
+export const postRegisterInfo = async (
+	email: string,
+	imageURL: string,
+	userName: string,
+	oauthInfo: 'NAVER' | 'KAKAO',
+) => {
+	const { data }: AxiosResponse<Api> = await defaultInstance.post(
+		`/api/register`,
+		{
+			email,
+			imageURL,
+			userName,
+			oauthInfo,
+		},
+	);
+	return data;
+};

--- a/client/src/apis/config.ts
+++ b/client/src/apis/config.ts
@@ -1,0 +1,6 @@
+const SERVER = '';
+
+// Postman 등등 mock 서버 주소를 단순하게 넣어주면 됩니다.
+const TESTSERVER = 'https://0114b1b9-5878-439f-9561-8a0e44e830ca.mock.pstmn.io';
+
+export { SERVER, TESTSERVER };

--- a/client/src/apis/utils/index.ts
+++ b/client/src/apis/utils/index.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { SERVER } from '../config';
+
+// SERVER 연결시 SERVER 로 변경 / 테스트시 TESTSERVER 로 변경
+const BASE_URL = SERVER;
+
+const axiosApi = (url: string, headers?: Record<string, unknown>) => {
+	const instance = axios.create({ baseURL: url, headers });
+	return instance;
+};
+
+const defaultInstance = axiosApi(BASE_URL);
+export default defaultInstance;

--- a/client/src/pages/LoadingPage/LoadingPage.tsx
+++ b/client/src/pages/LoadingPage/LoadingPage.tsx
@@ -1,49 +1,37 @@
 import React, { useEffect } from 'react';
-import axios, { AxiosResponse } from 'axios';
 import { useNavigate } from 'react-router-dom';
+// api
+import { postAuthInfo } from '../../apis/api/loginApi';
 // style
 import { Background, LoadingText } from './LoadingPageStyles';
 // img
 import loadingCat from '../../static/loadingCat.gif';
-// type
-import { LoginApi } from '../../types/responseData';
 
 const LoadingPage = () => {
 	const navigation = useNavigate();
-	const getSocialName = (url: URL) => {
+	const getSocialName = (url: URL): 'naver' | 'kakao' => {
 		const callback = url.pathname.split('/')[2];
-		let name = '';
-		if (callback.includes('naver')) {
-			name = 'naver';
-		} else if (callback.includes('kakao')) {
-			name = 'kakao';
-		}
+		let name: 'naver' | 'kakao' = 'kakao';
+		if (callback.includes('naver')) name = 'naver';
 		return name;
 	};
 
 	const postAuthrizationInfo = async (
-		socialName: string,
+		socialName: 'naver' | 'kakao',
 		authorizationCode: string,
 		state: string,
 	) => {
-		// `/api/oauth/${socialName}`,
-		// 	`https://918f89f3-ffda-4d81-9766-70caf106fd5b.mock.pstmn.io/api/oauth/naver/yes`,
-		const { data }: AxiosResponse<LoginApi> = await axios.post(
-			`https://918f89f3-ffda-4d81-9766-70caf106fd5b.mock.pstmn.io/api/oauth/naver/yes`,
-			{
-				authorizationCode,
-				state,
-			},
-		);
-
-		if (data.code === 200) {
-			if (data.email !== undefined) {
+		try {
+			const data = await postAuthInfo(socialName, authorizationCode, state);
+			if (data.code !== 200) navigation('/');
+			else if (data.email)
 				navigation('/register', {
 					state: { email: data.email, ouathInfo: 'NAVER' },
 				});
-			} else {
-				navigation('/home');
-			}
+			else navigation('/home');
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
 		}
 	};
 
@@ -51,6 +39,7 @@ const LoadingPage = () => {
 		const url = new URL(window.location.href);
 		const authorizationCode = url.searchParams.get('code');
 		const state = url.searchParams.get('state');
+		// TODO 만약에 여기서 getSocialName 에 아무것도 없다면 ? (인위적으로 클라이언트가 입력)
 		if (authorizationCode && state) {
 			const socialName = getSocialName(url);
 			postAuthrizationInfo(socialName, authorizationCode, state);


### PR DESCRIPTION
Motivation:
이전 주차부터 계속 메인 색상에 대한 피드백이 존재했다.
색상을 정하면서 시간을 보내는 것보다 일단 어떠한 색을 가지고 우선 개발을 하고,
추후 색상을 한번에 바꿀 수 있는 기능을 도입하는 것이 좋을 것 같다는 생각이 들어서 작업을 하게 되었다.
Modifications:
styled-component 에서 제공하는 themeProvider 를 통해서 태마색을 정하고
하위 스타일 컴포넌트들에서 props 를 통한 적용을 도입했다.
Result:

차후 매인 색상을 변경할 일이 존재할 경우 App.tsx 파일 속 theme 설정 변경을 통해서
한번에 색상을 변경할 수 있게 되었다.
설정을 한 이후 빌드, react dev server 에서 오류가 나지 않는 것을 확인했다.