### PR TITLE
[fe/refactor_apis] api 로직 분리

### DIFF
--- a/client/src/apis/api/loginApi.ts
+++ b/client/src/apis/api/loginApi.ts
@@ -1,0 +1,51 @@
+import { AxiosResponse } from 'axios';
+import defaultInstance from '../utils';
+// type
+import { LoginApi, Api } from '../../types/responseData';
+
+/**
+ * @param socialName 카카오나 네이버 사이트이름을 기입해준다.
+ * @param authorizationCode Oauth 사이트에서 리턴해준 코드를 기입해준다.
+ * @param state Oauth 사이트에서 리턴해준 state를 기입해준다.
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+export const postAuthInfo = async (
+	socialName: 'naver' | 'kakao',
+	authorizationCode: string,
+	state: string,
+): Promise<LoginApi> => {
+	const { data }: AxiosResponse<LoginApi> = await defaultInstance.post(
+		`/api/oauth/${socialName}`,
+		{
+			authorizationCode,
+			state,
+		},
+	);
+	return data;
+};
+
+/**
+ * @param email 서버에서 받은 email 정보를 기입한다.
+ * @param imageURL 오브젝트 스토리지에 올리고 받은 사진 위치 정보 기입 (변경 예정)
+ * @param userName 사용자 입력 닉네임 기입
+ * @param oauthInfo NAVER 혹은 KAKAO
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+// TODO 이미지 url 을 보내는 것이 아닌 form 으로 사진 데이터를 보내야한다.
+export const postRegisterInfo = async (
+	email: string,
+	imageURL: string,
+	userName: string,
+	oauthInfo: 'NAVER' | 'KAKAO',
+) => {
+	const { data }: AxiosResponse<Api> = await defaultInstance.post(
+		`/api/register`,
+		{
+			email,
+			imageURL,
+			userName,
+			oauthInfo,
+		},
+	);
+	return data;
+};

--- a/client/src/apis/config.ts
+++ b/client/src/apis/config.ts
@@ -1,0 +1,6 @@
+const SERVER = '';
+
+// Postman 등등 mock 서버 주소를 단순하게 넣어주면 됩니다.
+const TESTSERVER = 'https://0114b1b9-5878-439f-9561-8a0e44e830ca.mock.pstmn.io';
+
+export { SERVER, TESTSERVER };

--- a/client/src/apis/utils/index.ts
+++ b/client/src/apis/utils/index.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { SERVER } from '../config';
+
+// SERVER 연결시 SERVER 로 변경 / 테스트시 TESTSERVER 로 변경
+const BASE_URL = SERVER;
+
+const axiosApi = (url: string, headers?: Record<string, unknown>) => {
+	const instance = axios.create({ baseURL: url, headers });
+	return instance;
+};
+
+const defaultInstance = axiosApi(BASE_URL);
+export default defaultInstance;

--- a/client/src/pages/LoadingPage/LoadingPage.tsx
+++ b/client/src/pages/LoadingPage/LoadingPage.tsx
@@ -1,49 +1,37 @@
 import React, { useEffect } from 'react';
-import axios, { AxiosResponse } from 'axios';
 import { useNavigate } from 'react-router-dom';
+// api
+import { postAuthInfo } from '../../apis/api/loginApi';
 // style
 import { Background, LoadingText } from './LoadingPageStyles';
 // img
 import loadingCat from '../../static/loadingCat.gif';
-// type
-import { LoginApi } from '../../types/responseData';
 
 const LoadingPage = () => {
 	const navigation = useNavigate();
-	const getSocialName = (url: URL) => {
+	const getSocialName = (url: URL): 'naver' | 'kakao' => {
 		const callback = url.pathname.split('/')[2];
-		let name = '';
-		if (callback.includes('naver')) {
-			name = 'naver';
-		} else if (callback.includes('kakao')) {
-			name = 'kakao';
-		}
+		let name: 'naver' | 'kakao' = 'kakao';
+		if (callback.includes('naver')) name = 'naver';
 		return name;
 	};
 
 	const postAuthrizationInfo = async (
-		socialName: string,
+		socialName: 'naver' | 'kakao',
 		authorizationCode: string,
 		state: string,
 	) => {
-		// `/api/oauth/${socialName}`,
-		// 	`https://918f89f3-ffda-4d81-9766-70caf106fd5b.mock.pstmn.io/api/oauth/naver/yes`,
-		const { data }: AxiosResponse<LoginApi> = await axios.post(
-			`https://918f89f3-ffda-4d81-9766-70caf106fd5b.mock.pstmn.io/api/oauth/naver/yes`,
-			{
-				authorizationCode,
-				state,
-			},
-		);
-
-		if (data.code === 200) {
-			if (data.email !== undefined) {
+		try {
+			const data = await postAuthInfo(socialName, authorizationCode, state);
+			if (data.code !== 200) navigation('/');
+			else if (data.email)
 				navigation('/register', {
 					state: { email: data.email, ouathInfo: 'NAVER' },
 				});
-			} else {
-				navigation('/home');
-			}
+			else navigation('/home');
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
 		}
 	};
 
@@ -51,6 +39,7 @@ const LoadingPage = () => {
 		const url = new URL(window.location.href);
 		const authorizationCode = url.searchParams.get('code');
 		const state = url.searchParams.get('state');
+		// TODO 만약에 여기서 getSocialName 에 아무것도 없다면 ? (인위적으로 클라이언트가 입력)
 		if (authorizationCode && state) {
 			const socialName = getSocialName(url);
 			postAuthrizationInfo(socialName, authorizationCode, state);


### PR DESCRIPTION
Motivation: 
- api 코드들이 앞으로 많이 생길 것인데 이를 정리하고 따로 관리할 수 있으면 좋겠다고 생각했다.
- mock server 관련해서 진행을 할 때 url 을 모두 변경하는 작업은 번거로우니 이를 통합으로 한 번에 바꿀 수 있으면 좋겠다고 생각했다.
- 다른 프로젝트들의 코드를 보고 api 분리가 편하겠다는 생각을 했다.
- 참고 자료 정리
  - [React | 유지, 보수를 위한 API 통신은 어떻게 할까? (Axios 모듈화)](https://velog.io/@edie_ko/React-%EC%9C%A0%EC%A7%80-%EB%B3%B4%EC%88%98%EB%A5%BC-%EC%9C%84%ED%95%9C-API-%ED%86%B5%EC%8B%A0%EC%9D%80-%EC%96%B4%EB%96%BB%EA%B2%8C-%ED%95%A0%EA%B9%8C-Axios-%EB%AA%A8%EB%93%88%ED%99%94)
  - [리팩토링_API 모듈 분리](https://ghost4551.tistory.com/163)
  - [[TypeScript]Record Type 사용 방법](https://developer-talk.tistory.com/296)

Modifications: 
- apis 폴더를 만들고 내부에 정리를 했다.
  -  api: 실제 axios 로 통신하는 코드들을 역할에 맞게 정리한다.
  - services: 통신해서 받아온 데이터를 정돈하는 역할을 하는 파일을 모아둔다.
  - utils: 공통적으로 쓰이는 코드들을 정리한다.
  - config.ts: 서버와 mock 서버 주소 등의 공통적인 변수들을 저장해둔다.
- 기존에 작성된 axios 관련 코드들을 수정했다.

Result:
- 서버 주소 전환이 쉬워졌다.
- api 관련 코드들을 따로 빼서 확인하기 쉬워졌다.
- 기존 컴포넌트 코드들에서 api 관련 함수 관련 코드가 없어지고 이후 로직에 집중할 수 있다.
- 빌드시 오류 확인 완료