### PR TITLE
[be/board-crud] 게시판 작성, 수정 추가

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -32,7 +32,8 @@
 				"reflect-metadata": "^0.1.13",
 				"rimraf": "^3.0.2",
 				"rxjs": "^7.2.0",
-				"typeorm": "^0.3.10"
+				"typeorm": "^0.3.10",
+				"typeorm-naming-strategies": "^4.1.0"
 			},
 			"devDependencies": {
 				"@nestjs/cli": "^9.0.0",
@@ -8742,6 +8743,14 @@
 				}
 			}
 		},
+		"node_modules/typeorm-naming-strategies": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+			"integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+			"peerDependencies": {
+				"typeorm": "^0.2.0 || ^0.3.0"
+			}
+		},
 		"node_modules/typeorm/node_modules/buffer": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -15708,6 +15717,12 @@
 					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 				}
 			}
+		},
+		"typeorm-naming-strategies": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+			"integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+			"requires": {}
 		},
 		"typescript": {
 			"version": "4.8.4",

--- a/server/package.json
+++ b/server/package.json
@@ -45,7 +45,8 @@
 		"reflect-metadata": "^0.1.13",
 		"rimraf": "^3.0.2",
 		"rxjs": "^7.2.0",
-		"typeorm": "^0.3.10"
+		"typeorm": "^0.3.10",
+		"typeorm-naming-strategies": "^4.1.0"
 	},
 	"devDependencies": {
 		"@nestjs/cli": "^9.0.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -6,6 +6,8 @@ import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeORMConfig } from './configs/typeorm.config';
 import { AuthModule } from './auth/auth.module';
+import { BoardModule } from './board/board.module';
+import { ResponseInterceptor } from './interceptor/responseInterceptor';
 
 @Module({
   imports: [
@@ -13,8 +15,9 @@ import { AuthModule } from './auth/auth.module';
     UserModule,
     HttpModule,
     AuthModule,
+    BoardModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, ResponseInterceptor],
 })
 export class AppModule {}

--- a/server/src/board/board.controller.spec.ts
+++ b/server/src/board/board.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoardController } from './board.controller';
+
+describe('BoardController', () => {
+  let controller: BoardController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BoardController],
+    }).compile();
+
+    controller = module.get<BoardController>(BoardController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/board/board.controller.ts
+++ b/server/src/board/board.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   ParseIntPipe,
   Patch,
@@ -14,6 +15,7 @@ import { BoardService } from './board.service';
 import { CreateBoardDto } from './dto/createBoardDto';
 import { UpdateBoardDto } from './dto/updateBoaedDto';
 import { ResponseInterceptor } from '../interceptor/responseInterceptor';
+import { DeleteBoardDto } from 'board/dto/deleteBoardDto';
 
 @Controller('board')
 @UseInterceptors(ResponseInterceptor)
@@ -30,6 +32,12 @@ export class BoardController {
   @UsePipes(ValidationPipe)
   updateBoard(@Body() updateBoardDto: UpdateBoardDto) {
     this.boardService.updateBoard(updateBoardDto);
+    return;
+  }
+
+  @Delete('/')
+  deleteBoard(@Body() deleteBoardDto: DeleteBoardDto) {
+    this.boardService.deleteBoard(deleteBoardDto);
     return;
   }
 

--- a/server/src/board/board.controller.ts
+++ b/server/src/board/board.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Body,
+  Controller,
+  Get,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { BoardService } from './board.service';
+import { CreateBoardDto } from './dto/createBoardDto';
+import { UpdateBoardDto } from './dto/updateBoaedDto';
+import { ResponseInterceptor } from '../interceptor/responseInterceptor';
+
+@Controller('board')
+@UseInterceptors(ResponseInterceptor)
+export class BoardController {
+  constructor(private readonly boardService: BoardService) {}
+
+  @Post('/')
+  @UsePipes(ValidationPipe)
+  createBoard(@Body() createBoardDto: CreateBoardDto) {
+    return this.boardService.createBoard(createBoardDto);
+  }
+
+  @Patch('/')
+  @UsePipes(ValidationPipe)
+  updateBoard(@Body() updateBoardDto: UpdateBoardDto) {
+    this.boardService.updateBoard(updateBoardDto);
+    return;
+  }
+
+  // Todo 미완성
+  @Get('/')
+  getBoardList(
+    @Query('count', ParseIntPipe) count: number,
+    @Query('max_id', ParseIntPipe) maxId: number,
+  ) {
+    return this.boardService.getBoardList(count, maxId);
+  }
+
+  // @Get('/:boardId/comment')
+  // searchComment(
+  //   @Param('boardId', ParseIntPipe) boardId: number,
+  //   @Query('count', ParseIntPipe) count: number,
+  // ) {}
+  //
+  // @Get('/:boardId/like')
+  // searchLikePeople() {}
+  //
+  // @Post('/like')
+  // boardLike() {}
+  //
+  // @Delete('/like')
+  // boardLikeDelete() {}
+}

--- a/server/src/board/board.entity.ts
+++ b/server/src/board/board.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../user/user.entity';
+import { Photo } from './photo.entity';
+
+@Entity('board')
+export class Board {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  description: string;
+
+  @Column()
+  isStreet: boolean;
+
+  @Column()
+  location: string;
+
+  @Column()
+  latitude: number;
+
+  @Column()
+  longitude: number;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+  })
+  createdAt: Date;
+
+  @ManyToOne(() => User, (user) => user.boards)
+  user: User;
+
+  @OneToMany(() => Photo, (photo) => photo.board)
+  photos: Photo[];
+}

--- a/server/src/board/board.module.ts
+++ b/server/src/board/board.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { BoardController } from './board.controller';
+import { BoardService } from './board.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Board } from './board.entity';
+import { BoardRepository } from './board.repository';
+import { Photo } from './photo.entity';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Board, Photo]), UserModule],
+  controllers: [BoardController],
+  providers: [BoardService, BoardRepository],
+})
+export class BoardModule {}

--- a/server/src/board/board.repository.ts
+++ b/server/src/board/board.repository.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Board } from './board.entity';
+
+@Injectable()
+export class BoardRepository {
+  constructor(
+    @InjectRepository(Board) private boardRepository: Repository<Board>,
+  ) {}
+
+  // async save(board) {
+  //   return this.boardRepository.create(board);
+  // }
+}

--- a/server/src/board/board.service.spec.ts
+++ b/server/src/board/board.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BoardService } from './board.service';
+
+describe('BoardService', () => {
+  let service: BoardService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BoardService],
+    }).compile();
+
+    service = module.get<BoardService>(BoardService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/board/board.service.ts
+++ b/server/src/board/board.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Photo } from './photo.entity';
 import { UpdateBoardDto } from './dto/updateBoaedDto';
+import { DeleteBoardDto } from 'board/dto/deleteBoardDto';
 
 @Injectable()
 export class BoardService {
@@ -44,6 +45,10 @@ export class BoardService {
   updateBoard(updateBoardDto: UpdateBoardDto) {
     const { boardId, content } = updateBoardDto;
     this.boardRepository.update(boardId, { description: content });
+  }
+
+  deleteBoard(deleteBoardDto: DeleteBoardDto) {
+    this.boardRepository.delete({ id: deleteBoardDto.boardId });
   }
 
   // Todo 갯수 만큼 가져오기 미완성

--- a/server/src/board/board.service.ts
+++ b/server/src/board/board.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { CreateBoardDto } from './dto/createBoardDto';
+import { Board } from './board.entity';
+import { UserRepository } from '../user/user.repository';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Photo } from './photo.entity';
+import { UpdateBoardDto } from './dto/updateBoaedDto';
+
+@Injectable()
+export class BoardService {
+  constructor(
+    @InjectRepository(Board) private boardRepository: Repository<Board>,
+    @InjectRepository(Photo) private photoRepository: Repository<Photo>,
+    private readonly userRepository: UserRepository,
+  ) {}
+
+  async createBoard(createBoardDto: CreateBoardDto) {
+    const { content, image, isStreet, location, longitude, latitude, userId } =
+      createBoardDto;
+    const user = await this.userRepository.findById(userId);
+    const boardInfo = {
+      description: content,
+      isStreet,
+      location,
+      latitude,
+      longitude,
+      user,
+    };
+    const board = this.boardRepository.create(boardInfo);
+    await this.boardRepository.save(board);
+
+    image.forEach((url) => {
+      const imageInfo = {
+        url,
+        board,
+      };
+      this.photoRepository.save(imageInfo);
+    });
+
+    return { boardId: board.id };
+  }
+
+  updateBoard(updateBoardDto: UpdateBoardDto) {
+    const { boardId, content } = updateBoardDto;
+    this.boardRepository.update(boardId, { description: content });
+  }
+
+  // Todo 갯수 만큼 가져오기 미완성
+  async getBoardList(count, max_id) {
+    const boards = await this.boardRepository
+      .createQueryBuilder('board')
+      .leftJoinAndSelect('board.photos', 'photo')
+      .where('board.id= :id', { id: 2 })
+      .getOne();
+    console.log(boards, count, max_id);
+  }
+}

--- a/server/src/board/dto/createBoardDto.ts
+++ b/server/src/board/dto/createBoardDto.ts
@@ -1,0 +1,21 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class CreateBoardDto {
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNotEmpty()
+  image: string[];
+
+  @IsNotEmpty()
+  content: string;
+
+  @IsNotEmpty()
+  isStreet: boolean;
+
+  location: string | null;
+
+  latitude: number | null;
+
+  longitude: number | null;
+}

--- a/server/src/board/dto/deleteBoardDto.ts
+++ b/server/src/board/dto/deleteBoardDto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class DeleteBoardDto {
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNotEmpty()
+  boardId: number;
+}

--- a/server/src/board/dto/likeBoardDto.ts
+++ b/server/src/board/dto/likeBoardDto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class LikeBoardDto {
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNotEmpty()
+  boardId: number;
+}

--- a/server/src/board/dto/updateBoaedDto.ts
+++ b/server/src/board/dto/updateBoaedDto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class UpdateBoardDto {
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNotEmpty()
+  boardId: number;
+
+  @IsNotEmpty()
+  content: string;
+}

--- a/server/src/board/photo.entity.ts
+++ b/server/src/board/photo.entity.ts
@@ -9,6 +9,9 @@ export class Photo {
   @Column()
   url: string;
 
-  @ManyToOne(() => Board, (board) => board.photos)
+  @ManyToOne(() => Board, (board) => board.photos, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   board: Board;
 }

--- a/server/src/board/photo.entity.ts
+++ b/server/src/board/photo.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Board } from './board.entity';
+
+@Entity()
+export class Photo {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  url: string;
+
+  @ManyToOne(() => Board, (board) => board.photos)
+  board: Board;
+}

--- a/server/src/configs/typeorm.config.ts
+++ b/server/src/configs/typeorm.config.ts
@@ -1,6 +1,8 @@
 import * as dotenv from 'dotenv';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from 'src/user/user.entity';
+import { Board } from '../board/board.entity';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 dotenv.config();
 
@@ -11,6 +13,7 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
-  entities: [User],
+  entities: [User, Board],
   synchronize: true,
+  namingStrategy: new SnakeNamingStrategy(),
 };

--- a/server/src/configs/typeorm.config.ts
+++ b/server/src/configs/typeorm.config.ts
@@ -3,6 +3,7 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from 'src/user/user.entity';
 import { Board } from '../board/board.entity';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { Photo } from 'board/photo.entity';
 
 dotenv.config();
 
@@ -13,7 +14,7 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
-  entities: [User, Board],
+  entities: [User, Board, Photo],
   synchronize: true,
   namingStrategy: new SnakeNamingStrategy(),
 };

--- a/server/src/interceptor/responseInterceptor.ts
+++ b/server/src/interceptor/responseInterceptor.ts
@@ -1,0 +1,28 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { map, Observable } from 'rxjs';
+
+export interface Response<T> {
+  data: T;
+}
+
+@Injectable()
+export class ResponseInterceptor<T> implements NestInterceptor<T, Response<T>> {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<Response<T>> {
+    const statusCode = context.switchToHttp().getResponse().statusCode;
+    return next.handle().pipe(
+      map((data) => ({
+        statusCode,
+        message: statusCode < 300 ? 'SUCCESS' : 'FAIL',
+        data,
+      })),
+    );
+  }
+}

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { OauthInfo } from '../auth/model/oauth-info.enum';
+import { Board } from '../board/board.entity';
 
 @Entity()
 export class User {
@@ -17,4 +18,7 @@ export class User {
 
   @Column()
   profile_url: string;
+
+  @OneToMany(() => Board, (board) => board.user)
+  boards: Board[];
 }

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -13,6 +13,12 @@ export class UserRepository {
     return await this.userRepository.find();
   }
 
+  async findById(userId: number): Promise<User> {
+    return await this.userRepository.findOneBy({
+      id: userId,
+    });
+  }
+
   async findByOauthInfo(
     email: string,
     oauth_info: OauthInfo,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,7 +9,6 @@
 		"target": "es2017",
 		"sourceMap": true,
 		"outDir": "./dist",
-		"baseUrl": "./",
 		"incremental": true,
 		"skipLibCheck": true,
 		"strictNullChecks": false,
@@ -17,6 +16,12 @@
 		"strictBindCallApply": false,
 		"forceConsistentCasingInFileNames": false,
 		"noFallthroughCasesInSwitch": false,
-		"moduleResolution": "node"
+		"moduleResolution": "node",
+		"baseUrl": ".",
+		"paths": {
+			"board/*": [
+				"src/board/*"
+			],
+		}
 	}
 }


### PR DESCRIPTION
Motivation :
- 게시글 CRUD API 구축
- 정형화된 response가 필요하다.

Modifications:
- `board` crud api 추가
- `board`,`user`,`photo` 엔티티 연관관계 설정
- `response interceptor` 추가 (컨트롤러별 적용은 별도로)
- 엔티티 클래스 - db 테이블 끼리 변수명 자동변환 모듈 추가 

Result:
- 엔티티 내부 변수를 카멜케이스로 지어도 db테이블엔 스네이크 케이스로 들어가 되었다.
- 응답시 interceptor를 거쳐 statuscode와 message가 들어가게 되었다. ( 추후 수정 필요 )
close #36
close #37
close #47
close #48 