### PR TITLE
[be/get-boardlist] 게시글을 n개씩 불러온다

### DIFF
--- a/server/src/board/board.controller.ts
+++ b/server/src/board/board.controller.ts
@@ -41,13 +41,12 @@ export class BoardController {
     return;
   }
 
-  // Todo 미완성
   @Get('/')
   getBoardList(
     @Query('count', ParseIntPipe) count: number,
     @Query('max_id', ParseIntPipe) maxId: number,
   ) {
-    return this.boardService.getBoardList(count, maxId);
+    return this.boardService.getLastBoardList(count, maxId);
   }
 
   // @Get('/:boardId/comment')

--- a/server/src/board/board.entity.ts
+++ b/server/src/board/board.entity.ts
@@ -9,13 +9,13 @@ import {
 import { User } from '../user/user.entity';
 import { Photo } from './photo.entity';
 
-@Entity('board')
+@Entity()
 export class Board {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column()
-  description: string;
+  content: string;
 
   @Column()
   isStreet: boolean;
@@ -28,6 +28,14 @@ export class Board {
 
   @Column()
   longitude: number;
+
+  // Todo 연관관계 매핑필요
+  @Column()
+  like: number;
+
+  // Todo 연관관계 매핑필요
+  @Column()
+  comment: number;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/server/src/board/board.entity.ts
+++ b/server/src/board/board.entity.ts
@@ -30,11 +30,11 @@ export class Board {
   longitude: number;
 
   // Todo 연관관계 매핑필요
-  @Column()
+  @Column({ nullable: true })
   like: number;
 
   // Todo 연관관계 매핑필요
-  @Column()
+  @Column({ nullable: true })
   comment: number;
 
   @CreateDateColumn({

--- a/server/src/board/board.module.ts
+++ b/server/src/board/board.module.ts
@@ -6,10 +6,11 @@ import { Board } from './board.entity';
 import { BoardRepository } from './board.repository';
 import { Photo } from './photo.entity';
 import { UserModule } from '../user/user.module';
+import { PhotoRepository } from 'board/photo.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Board, Photo]), UserModule],
   controllers: [BoardController],
-  providers: [BoardService, BoardRepository],
+  providers: [BoardService, BoardRepository, PhotoRepository],
 })
 export class BoardModule {}

--- a/server/src/board/board.repository.ts
+++ b/server/src/board/board.repository.ts
@@ -1,15 +1,25 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Board } from './board.entity';
+import { InjectRepository } from '@nestjs/typeorm';
 
 @Injectable()
 export class BoardRepository {
   constructor(
     @InjectRepository(Board) private boardRepository: Repository<Board>,
   ) {}
-
-  // async save(board) {
-  //   return this.boardRepository.create(board);
-  // }
+  //
+  //   async save(board: Board) {
+  //     await this.boardRepository.save(board);
+  //   }
+  //
+  //   async create(board: Board) {
+  //     await this.boardRepository.create(board);
+  //   }
+  //
+  //   async update(id, updatedData) {
+  //     await this.boardRepository.update(id,updatedData);
+  //   }
+  //
+  //   async getLastBoardList(count, number) {}
 }

--- a/server/src/board/board.repository.ts
+++ b/server/src/board/board.repository.ts
@@ -8,18 +8,48 @@ export class BoardRepository {
   constructor(
     @InjectRepository(Board) private boardRepository: Repository<Board>,
   ) {}
-  //
-  //   async save(board: Board) {
-  //     await this.boardRepository.save(board);
-  //   }
-  //
-  //   async create(board: Board) {
-  //     await this.boardRepository.create(board);
-  //   }
-  //
-  //   async update(id, updatedData) {
-  //     await this.boardRepository.update(id,updatedData);
-  //   }
-  //
-  //   async getLastBoardList(count, number) {}
+
+  async save(board: Board) {
+    await this.boardRepository.save(board);
+  }
+
+  async create(board: Board) {
+    await this.boardRepository.create(board);
+  }
+
+  async update(id: number, updatedData) {
+    await this.boardRepository.update(id, updatedData);
+  }
+
+  async delete(idInfo) {
+    await this.boardRepository.delete(idInfo);
+  }
+
+  async findLastBoardList(count: number, max_id) {
+    // limit 혹은 take 적용 필요할 듯..
+    const qb = await this.boardRepository
+      .createQueryBuilder('board')
+      .select(['board', 'user.id', 'user.name', 'user.profileUrl', 'photo.url'])
+      .leftJoin('board.photos', 'photo')
+      .leftJoin('board.user', 'user')
+      .orderBy('board.createdAt', 'DESC');
+
+    let boards;
+
+    if (max_id != -1) {
+      const lastBoard = await this.boardRepository.findOneBy({ id: max_id });
+      boards = await qb
+        .andWhere('board.created_at < :created_at', {
+          created_at: lastBoard.createdAt,
+        })
+        .getMany();
+    } else {
+      boards = await qb.getMany();
+    }
+
+    boards = boards.slice(0, count);
+    const _count = boards.length;
+    const nextMaxId = boards[0].id;
+    return { boards, count: _count, nextMaxId };
+  }
 }

--- a/server/src/board/board.service.ts
+++ b/server/src/board/board.service.ts
@@ -21,7 +21,7 @@ export class BoardService {
       createBoardDto;
     const user = await this.userRepository.findById(userId);
     const boardInfo = {
-      description: content,
+      content,
       isStreet,
       location,
       latitude,

--- a/server/src/board/dto/createBoardDto.ts
+++ b/server/src/board/dto/createBoardDto.ts
@@ -5,7 +5,7 @@ export class CreateBoardDto {
   userId: number;
 
   @IsNotEmpty()
-  image: string[];
+  images: string[];
 
   @IsNotEmpty()
   content: string;

--- a/server/src/board/photo.repository.ts
+++ b/server/src/board/photo.repository.ts
@@ -1,0 +1,18 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Photo } from 'board/photo.entity';
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PhotoRepository {
+  constructor(
+    @InjectRepository(Photo) private photoRepository: Repository<Photo>,
+  ) {}
+  async save(photo: Photo) {
+    await this.photoRepository.save(photo);
+  }
+
+  async create(photo: Photo) {
+    await this.photoRepository.create(photo);
+  }
+}

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -14,10 +14,10 @@ export class User {
   email: string;
 
   @Column()
-  oauth_info: OauthInfo;
+  oauthInfo: OauthInfo;
 
   @Column()
-  profile_url: string;
+  profileUrl: string;
 
   @OneToMany(() => Board, (board) => board.user)
   boards: Board[];

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -24,7 +24,7 @@ export class UserRepository {
     oauth_info: OauthInfo,
   ): Promise<User | undefined> {
     return await this.userRepository.findOne({
-      where: { email: email, oauth_info: oauth_info },
+      where: { email: email, oauthInfo: oauth_info },
     });
   }
 


### PR DESCRIPTION
Motivation :
- 이전에 불러왔던 게시글을 기준으로 count 개씩 최신 게시글들을 불러 온다
- 
Modifications:
- board service에 게시글 불러오기 추가

Result:
- pathVariable에 불러올 게시글 수 `count` 가장 최근에 불러온 게시글 id `max_id` 를 담아 게시글을 최신순으로 불러올 수 있다
- close #35