### PR TITLE
[be/refactor] plainToInstance 사용 및 statusCode 속성 변경

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
 
   async register(registerUserDto: RegisterUserDto) {
     // TODO: OauthInfo 추가
-    const { email, imageURL, userName } = registerUserDto;
+    const { email } = registerUserDto;
 
     const find = await this.userRepository.findByOauthInfo(
       email,
@@ -37,12 +37,7 @@ export class AuthService {
       throw new ConflictException('이미 존재하는 유저입니다.');
     }
 
-    const user = {
-      name: userName,
-      email: email,
-      oauth_info: OauthInfo.NAVER,
-      profile_url: imageURL,
-    };
+    const user = registerUserDto.toEntity();
     this.userRepository.save(user);
 
     return { code: 200, message: 'Success' };

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -7,6 +7,8 @@ import { RegisterUserDto } from './dto/user-register.dto';
 import { OauthNaverDto } from './dto/oauth-naver.dto';
 import { UserRepository } from 'src/user/user.repository';
 import { firstValueFrom, map } from 'rxjs';
+import { plainToInstance } from 'class-transformer';
+import { User } from 'src/user/user.entity';
 
 @Injectable()
 export class AuthService {
@@ -26,7 +28,7 @@ export class AuthService {
 
   async register(registerUserDto: RegisterUserDto) {
     // TODO: OauthInfo 추가
-    const { email } = registerUserDto;
+    const { email, imageURL, userName } = registerUserDto;
 
     const find = await this.userRepository.findByOauthInfo(
       email,
@@ -37,7 +39,13 @@ export class AuthService {
       throw new ConflictException('이미 존재하는 유저입니다.');
     }
 
-    const user = registerUserDto.toEntity();
+    const userInfo = {
+      name: userName,
+      email: email,
+      oauth_info: OauthInfo.NAVER,
+      profile_url: imageURL,
+    };
+    const user = plainToInstance(User, userInfo);
     this.userRepository.save(user);
 
     return { code: 200, message: 'Success' };

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -20,9 +20,9 @@ export class AuthService {
   // 홈페이지에서 로그인 확인 요청시 redis에서 세션 id 확인
   async validateLogin(request: Request) {
     const user = redisClient.get(request.sessionID);
-    if (!user) return { code: 500, message: 'Unauthorized User' };
+    if (!user) return { statusCode: 500, message: 'Unauthorized User' };
     else {
-      return { code: 200, message: 'SUCCESS' };
+      return { statusCode: 200, message: 'SUCCESS' };
     }
   }
 
@@ -48,7 +48,7 @@ export class AuthService {
     const user = plainToInstance(User, userInfo);
     this.userRepository.save(user);
 
-    return { code: 200, message: 'Success' };
+    return { statusCode: 200, message: 'Success' };
   }
 
   // // 로그인요청시 기존유저인지 검증 아니라면 회원가입 페이지로
@@ -61,13 +61,13 @@ export class AuthService {
     if (user) {
       await redisClient.set(request.sessionID, email);
       return {
-        code: 200,
+        statusCode: 200,
         userId: user.id,
         message: 'Success',
       };
     } else {
       return {
-        code: 200,
+        statusCode: 200,
         message: 'Register Required',
         redirect: true,
         email: email,
@@ -80,9 +80,9 @@ export class AuthService {
     request.session.destroy((err) => {
       if (err) {
         console.log(err);
-        return { code: 500, message: 'Fail' };
+        return { statusCode: 500, message: 'Fail' };
       } else {
-        return { code: 200, message: 'Success' };
+        return { statusCode: 200, message: 'Success' };
       }
     });
   }

--- a/server/src/auth/dto/user-register.dto.ts
+++ b/server/src/auth/dto/user-register.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty } from 'class-validator';
-// import { OauthInfo } from '../model/OauthInfo.enum';
+import { User } from 'src/user/user.entity';
+import { OauthInfo } from '../model/oauth-info.enum';
 
 export class RegisterUserDto {
   @IsNotEmpty()
@@ -13,4 +14,13 @@ export class RegisterUserDto {
 
   // @IsNotEmpty()
   // oauthInfo: OauthInfo;
+
+  toEntity(): User {
+    const user = new User();
+    user.email = this.email;
+    user.name = this.userName;
+    user.profile_url = this.imageURL;
+    user.oauth_info = OauthInfo.NAVER;
+    return user;
+  }
 }

--- a/server/src/auth/dto/user-register.dto.ts
+++ b/server/src/auth/dto/user-register.dto.ts
@@ -1,6 +1,4 @@
 import { IsNotEmpty } from 'class-validator';
-import { User } from 'src/user/user.entity';
-import { OauthInfo } from '../model/oauth-info.enum';
 
 export class RegisterUserDto {
   @IsNotEmpty()

--- a/server/src/auth/dto/user-register.dto.ts
+++ b/server/src/auth/dto/user-register.dto.ts
@@ -14,13 +14,4 @@ export class RegisterUserDto {
 
   // @IsNotEmpty()
   // oauthInfo: OauthInfo;
-
-  toEntity(): User {
-    const user = new User();
-    user.email = this.email;
-    user.name = this.userName;
-    user.profile_url = this.imageURL;
-    user.oauth_info = OauthInfo.NAVER;
-    return user;
-  }
 }

--- a/server/src/user/user.repository.ts
+++ b/server/src/user/user.repository.ts
@@ -34,12 +34,7 @@ export class UserRepository {
     });
   }
 
-  async save(user: {
-    name: string;
-    email: string;
-    oauth_info: OauthInfo;
-    profile_url: string;
-  }) {
+  async save(user: User) {
     return await this.userRepository.save(user);
   }
 }


### PR DESCRIPTION
Motivation :
- 기존에는 User Entity의 generated column을 제외한 타입을 따로 선언해서 명시해주었는데, 이 부분이 번거롭고 변경 시 유지 보수가 어렵다고 생각해 Dto에 toEntity()를 구현하는 것을 고려하였으나, plainToInstance라는 모델매퍼를 사용해 literal 객체를 바로 User Entity 객체로 변환시켜주었다.
- 변경된 api 명세에 따라 response data 속성 변경

Modifications:
- plainToInstance를 사용해 User 객체 생성
- response data의 code 속성 statusCode로 변경

Result:
dto나 literal 객체를 손쉽게 entity 객체로 변환 가능
api 명세에 맞는 response 회신 가능