### PR TITLE
[fe/connect home api] 홈 화면에서 페이지 라우팅 추가 및 API 연결

### DIFF
--- a/client/src/apis/api/BoardApi.ts
+++ b/client/src/apis/api/BoardApi.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { defaultInstance } from '../utils';
-import { Api, BoardApi } from '../../types/responseData';
+import { Api, BoardApi, LikeListApi } from '../../types/responseData';
 
 /**
  * @param count 서버에서 받아올 데이터의 수
@@ -35,4 +35,70 @@ const deleteBoardData = async (
   return data;
 };
 
-export { getBoardData, deleteBoardData };
+/**
+ * @param boardId 수정할 게시물의 ID
+ * @param userId 해당 게시물을 작성한 user ID
+ * @param content 수정할 본문 내용
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+const updateBoardData = async (
+  boardId: string,
+  userId: number,
+  content: string,
+): Promise<Api> => {
+  const { data }: AxiosResponse<Api> = await defaultInstance.patch(
+    '/api/board',
+    { boardId, userId, content },
+  );
+  return data;
+};
+
+/**
+ * @param boardId 좋아요할 게시물의 ID
+ * @param userId 좋아요를 요청하는 user ID
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+const postLikeBoard = async (boardId: string, userId: number): Promise<Api> => {
+  const { data }: AxiosResponse<Api> = await defaultInstance.post(
+    '/api/board/like',
+    { boardId, userId },
+  );
+  return data;
+};
+
+/**
+ * @param boardId 좋아요를 취소할 게시물의 ID
+ * @param userId 좋아요 취소를 요청하는 user ID
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+const deleteLikeBoard = async (
+  boardId: string,
+  userId: number,
+): Promise<Api> => {
+  const { data }: AxiosResponse<Api> = await defaultInstance.delete(
+    '/api/board/like',
+    { data: { boardId, userId } },
+  );
+  return data;
+};
+
+/**
+ * @param boardId 좋아요를 누른 사람들의 목록을 가져올 게시물의 ID
+ * @returns 서버와의 통신 이후 결과를 보내준다.
+ */
+const getLikeList = async (boardId: string) => {
+  const { data }: AxiosResponse<LikeListApi> = await defaultInstance.get(
+    `/api/board/like?=${boardId}`,
+    {},
+  );
+  return data;
+};
+
+export {
+  getBoardData,
+  deleteBoardData,
+  updateBoardData,
+  postLikeBoard,
+  deleteLikeBoard,
+  getLikeList,
+};

--- a/client/src/components/BoardItem/BoardBody/BoardBody.tsx
+++ b/client/src/components/BoardItem/BoardBody/BoardBody.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   BoardBodyWrapper,
   BoardBodyContainer,
@@ -11,6 +12,7 @@ import likeButton from '../../../static/emptyHeart.svg';
 import commentButton from '../../../static/commentBtn.svg';
 
 interface BoardBodyProps {
+  boardId: string;
   content: string;
   like: number;
   comment: number;
@@ -18,14 +20,15 @@ interface BoardBodyProps {
 }
 
 const BoardBody = (props: BoardBodyProps) => {
-  const { content, like, comment, createAt } = props;
+  const { boardId, content, like, comment, createAt } = props;
+  const navigate = useNavigate();
 
   const onClickCommentIcon = () => {
-    /* 해당 게시글의 댓글 창으로 이동 */
+    navigate(`/comment/${boardId}`);
   };
 
   const onClickHeartIcon = () => {
-    /* 이 게시글에 대한 좋아요 요청 */
+    /* TODO: 이 게시글에 대한 좋아요 요청 */
   };
 
   return (

--- a/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
+++ b/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 // recoil
 import { useRecoilValue } from 'recoil';
 import user from '../../../store/userAtom';
@@ -12,6 +13,7 @@ import {
 // img
 import pinIcon from '../../../static/pinIcon.svg';
 import menuButton from '../../../static/menuBtn.svg';
+// component
 import BoardMenu from '../BoardMenu/BoardMenu';
 
 interface BoardHeaderProps {
@@ -24,6 +26,7 @@ interface BoardHeaderProps {
 }
 
 const BoardHeader = (props: BoardHeaderProps) => {
+  const navigate = useNavigate();
   const { userId, boardId, userProfile, userName, isStreet, location } = props;
   const [menuHideOption, setMenuHideOption] = useState(true);
   const userData = useRecoilValue(user);
@@ -35,6 +38,7 @@ const BoardHeader = (props: BoardHeaderProps) => {
 
   const onClickUserInfo = () => {
     /* TODO: 해당 유저 페이지로 이동 */
+    navigate('/home');
   };
 
   return (

--- a/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
+++ b/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
@@ -15,11 +15,12 @@ interface BoardHeaderProps {
   boardId: string;
   userProfile: string;
   userName: string;
+  isStreet: boolean;
   location: string | null;
 }
 
 const BoardHeader = (props: BoardHeaderProps) => {
-  const { userId, boardId, userProfile, userName, location } = props;
+  const { userId, boardId, userProfile, userName, isStreet, location } = props;
   const [menuHideOption, setMenuHideOption] = useState(true);
 
   const onClickMenu = () => {
@@ -27,7 +28,7 @@ const BoardHeader = (props: BoardHeaderProps) => {
   };
 
   const onClickUserInfo = () => {
-    /* 해당 유저 페이지로 이동 */
+    /* TODO: 해당 유저 페이지로 이동 */
   };
 
   return (
@@ -39,7 +40,7 @@ const BoardHeader = (props: BoardHeaderProps) => {
           </UserProfileImageContainer>
           <BoardHeaderInfoContainer>
             <div className="user-name">{userName}</div>
-            {location !== null ? (
+            {isStreet === true ? (
               <div>
                 <img src={pinIcon} alt="pin icon" />
                 <div className="location">{location}</div>

--- a/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
+++ b/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
@@ -1,4 +1,8 @@
 import React, { useState } from 'react';
+// recoil
+import { useRecoilValue } from 'recoil';
+import user from '../../../store/userAtom';
+// style
 import {
   BoardHeaderWrapper,
   BoardHeaderContainer,
@@ -22,6 +26,8 @@ interface BoardHeaderProps {
 const BoardHeader = (props: BoardHeaderProps) => {
   const { userId, boardId, userProfile, userName, isStreet, location } = props;
   const [menuHideOption, setMenuHideOption] = useState(true);
+  const userData = useRecoilValue(user);
+  const loginedUserId = userData.userId;
 
   const onClickMenu = () => {
     setMenuHideOption(!menuHideOption);
@@ -50,9 +56,13 @@ const BoardHeader = (props: BoardHeaderProps) => {
             )}
           </BoardHeaderInfoContainer>
         </BoardHeaderContainer>
-        <button type="button" onClick={onClickMenu}>
-          <img src={menuButton} alt="Create/Delete DropDown" />
-        </button>
+        {/* // 현재 로그인한 계정의 게시글만 수정/삭제할 수 있도록 함
+        {loginedUserId === userId ? ( */}
+        {loginedUserId !== null ? ( // 테스트용
+          <button type="button" onClick={onClickMenu}>
+            <img src={menuButton} alt="Create/Delete DropDown" />
+          </button>
+        ) : null}
       </BoardHeaderWrapper>
       {menuHideOption ? null : (
         <BoardMenu

--- a/client/src/components/BoardItem/BoardImages/BoardImages.tsx
+++ b/client/src/components/BoardItem/BoardImages/BoardImages.tsx
@@ -5,6 +5,7 @@ interface BoardImagesProps {
   src: string;
 }
 
+/* TODO: 캐러셀 구현 예정 */
 const BoardImages = (props: BoardImagesProps) => {
   const { src } = props;
   return <BoardImagesContainer src={src} />;

--- a/client/src/components/BoardItem/BoardItem.tsx
+++ b/client/src/components/BoardItem/BoardItem.tsx
@@ -7,29 +7,29 @@ import BoardBackground from './BoardItemStyles';
 
 const BoardItem = (props: Board) => {
   const {
-    userId,
-    userName,
-    userProfile,
-    boardId,
+    id,
     content,
-    url,
+    isStreet,
     like,
     comment,
     createAt,
     location,
+    photos,
+    user,
   } = props;
   return (
-    <BoardBackground key={boardId}>
+    <BoardBackground key={id}>
       <BoardHeader
-        userId={userId}
-        boardId={boardId}
-        userProfile={userProfile}
-        userName={userName}
+        userId={user.id}
+        boardId={id}
+        userProfile={user.profileUrl}
+        userName={user.name}
+        isStreet={isStreet}
         location={location}
       />
-      <BoardImages src={url[0]} />
+      <BoardImages src={photos.url[0]} />
       <BoardBody
-        boardId={boardId}
+        boardId={id}
         content={content}
         like={like}
         comment={comment}

--- a/client/src/components/BoardItem/BoardItem.tsx
+++ b/client/src/components/BoardItem/BoardItem.tsx
@@ -29,6 +29,7 @@ const BoardItem = (props: Board) => {
       />
       <BoardImages src={url[0]} />
       <BoardBody
+        boardId={boardId}
         content={content}
         like={like}
         comment={comment}

--- a/client/src/components/BoardItem/BoardMenu/BoardMenu.tsx
+++ b/client/src/components/BoardItem/BoardMenu/BoardMenu.tsx
@@ -12,8 +12,7 @@ const BoardMenu = (props: BoardMenuProps) => {
   const { boardId, userId, changeHideOption } = props;
   const modalRef = useRef<HTMLDivElement>(null);
 
-  const deleteBoard = () => {
-    /* 해당 게시글 삭제 요청 */
+  const requestDeleteBoard = () => {
     try {
       deleteBoardData(boardId, userId);
     } catch (error) {
@@ -27,7 +26,9 @@ const BoardMenu = (props: BoardMenuProps) => {
 
   useEffect(() => {
     const clickOutOfModal = (event: MouseEvent) => {
-      /* mousedown 이벤트가 발생한 영역이 모달창이 아닐 때, 모달창 제거 처리 */
+      /** mousedown 이벤트가 발생한 영역이 모달창이 아닐 때, 모달창 제거 처리
+       *  TODO: 메뉴 버튼 클릭시 hideOption 상태 변화가 2번 일어나 메뉴가 닫히지 않는 버그
+       */
       if (
         event.currentTarget !== null &&
         modalRef.current &&
@@ -50,7 +51,7 @@ const BoardMenu = (props: BoardMenuProps) => {
       <button type="button" onClick={modifyBoard}>
         수정하기
       </button>
-      <button type="button" onClick={deleteBoard}>
+      <button type="button" onClick={requestDeleteBoard}>
         삭제하기
       </button>
       <button type="button" className="last-content" onClick={changeHideOption}>

--- a/client/src/components/NormalTopBar/NormalTopBar.tsx
+++ b/client/src/components/NormalTopBar/NormalTopBar.tsx
@@ -11,20 +11,46 @@ const NoramlTopBarContainer = styled.div`
   display: flex;
   flex-direction: row;
   padding: 9px 12px;
+  align-items: center;
+  justify-content: space-between;
+
+  button {
+    background-color: transparent;
+    border: 0px;
+  }
+`;
+
+const NormalTopBarLogoContainer = styled.div`
+  display: flex;
   justify-items: start;
   align-items: center;
   gap: 1rem;
 `;
+interface NormalTopBarProps {
+  buttonData: {
+    buttonImg: string;
+    eventHandler: () => void;
+    description: string;
+  } | null;
+}
 
-const NormalTopBar = () => {
+const NormalTopBar = (props: NormalTopBarProps) => {
+  const { buttonData } = props;
   return (
     <NoramlTopBarContainer>
-      <img src={logo} alt="Logo" style={{ width: '3rem', height: '3rem' }} />
-      <img
-        src={appName}
-        alt="App Name"
-        style={{ width: '10rem', height: '2rem' }}
-      />
+      <NormalTopBarLogoContainer>
+        <img src={logo} alt="Logo" style={{ width: '3rem', height: '3rem' }} />
+        <img
+          src={appName}
+          alt="App Name"
+          style={{ width: '10rem', height: '2rem' }}
+        />
+      </NormalTopBarLogoContainer>
+      {buttonData !== null ? (
+        <button type="button" onClick={buttonData.eventHandler}>
+          <img src={buttonData.buttonImg} alt={buttonData.description} />
+        </button>
+      ) : null}
     </NoramlTopBarContainer>
   );
 };

--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 // img
 import testImage from '../../static/testImage.png';
 import catFootprint from '../../static/catFootprint.svg';
+import addPostButtonImg from '../../static/addPost.svg';
 // component
 import NavBar from '../../components/NavBar/NavBar';
 import NormalTopBar from '../../components/NormalTopBar/NormalTopBar';
@@ -73,8 +75,16 @@ const dummyBoards: Board[] = [
 ];
 
 const HomePage = () => {
+  const navigate = useNavigate();
   const [boards, setBoards] = useState<Board[]>([]);
   const requestCount = 10000;
+  const addPostButton = {
+    buttonImg: addPostButtonImg,
+    eventHandler: () => {
+      navigate('/new-post');
+    },
+    description: '게시물을 추가할래요.',
+  };
   const getData = async () => {
     const { statusCode, message, data } = await getBoardData(
       requestCount,
@@ -96,7 +106,7 @@ const HomePage = () => {
 
   return (
     <>
-      <NormalTopBar />
+      <NormalTopBar buttonData={addPostButton} />
       <BoardContainer>
         {boards.map((board) => {
           return BoardItem(board);

--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -81,7 +81,7 @@ const HomePage = () => {
       '-1',
     );
     if (statusCode !== 200) throw new Error(message);
-    if (data.boards === undefined) return;
+    if (data === undefined) return;
     setBoards(boards.concat(data.boards));
   };
 

--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -17,40 +17,55 @@ const timeStamp = `${today.getFullYear()}.${
 }.${today.getDate()}`;
 const boards: Board[] = [
   {
-    userId: 1,
-    userName: 'Test User1',
-    userProfile: '../../defaultProfile.svg',
-    boardId: '1',
+    id: '1',
     content: '게시글 테스트1',
-    url: [testImage],
+    isStreet: true,
     like: 2,
     comment: 2,
     createAt: timeStamp,
     location: '서울특별시 역삼동',
+    photos: {
+      url: [testImage],
+    },
+    user: {
+      id: 1,
+      name: 'Test User1',
+      profileUrl: '../../defaultProfile.svg',
+    },
   },
   {
-    userId: 2,
-    userName: 'Test User2',
-    userProfile: '../../defaultProfile.svg',
-    boardId: '2',
+    id: '2',
     content: '게시글 테스트2',
-    url: [testImage],
+    isStreet: false,
     like: 0,
     comment: 0,
     createAt: timeStamp,
     location: null,
+    photos: {
+      url: [testImage],
+    },
+    user: {
+      id: 2,
+      name: 'Test User2',
+      profileUrl: '../../defaultProfile.svg',
+    },
   },
   {
-    userId: 3,
-    userName: 'Test User3',
-    userProfile: '../../defaultProfile.svg',
-    boardId: '3',
+    id: '3',
     content: 'sdasdasdasdsadasdsadadsadasdsadasdadsdadadadsdasdadaddssadsd',
-    url: [testImage],
+    isStreet: true,
     like: 123,
     comment: 0,
     createAt: timeStamp,
     location: '동탄 어딘가',
+    photos: {
+      url: [testImage],
+    },
+    user: {
+      id: 3,
+      name: 'Test User3',
+      profileUrl: '../../defaultProfile.svg',
+    },
   },
 ];
 
@@ -72,7 +87,6 @@ const HomePage = () => {
           <p>모든 게시물을 확인했습니다</p>
         </BoardEnd>
       </BoardContainer>
-      {/* <TempBody src={tempHomeBody} alt="Temp" /> */}
       <NavBar />
     </>
   );

--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 // img
 import testImage from '../../static/testImage.png';
 import catFootprint from '../../static/catFootprint.svg';
 // component
 import NavBar from '../../components/NavBar/NavBar';
 import NormalTopBar from '../../components/NormalTopBar/NormalTopBar';
+import BoardItem from '../../components/BoardItem/BoardItem';
 // style
 import { BoardContainer, BoardEnd } from './HomePageStyles';
-import BoardItem from '../../components/BoardItem/BoardItem';
+// type
 import { Board } from '../../types/responseData';
+// api
+import { getBoardData } from '../../apis/api/BoardApi';
 
 /* Test Data */
 const today = new Date(Date.now());
 const timeStamp = `${today.getFullYear()}.${
   today.getMonth() + 1
 }.${today.getDate()}`;
-const boards: Board[] = [
+const dummyBoards: Board[] = [
   {
     id: '1',
     content: '게시글 테스트1',
@@ -70,11 +73,35 @@ const boards: Board[] = [
 ];
 
 const HomePage = () => {
+  const [boards, setBoards] = useState<Board[]>([]);
+  const requestCount = 10000;
+  const getData = async () => {
+    const { statusCode, message, data } = await getBoardData(
+      requestCount,
+      '-1',
+    );
+    if (statusCode !== 200) throw new Error(message);
+    if (data.boards === undefined) return;
+    setBoards(boards.concat(data.boards));
+  };
+
+  useEffect(() => {
+    try {
+      getData();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  }, []);
+
   return (
     <>
       <NormalTopBar />
       <BoardContainer>
         {boards.map((board) => {
+          return BoardItem(board);
+        })}
+        {dummyBoards.map((board) => {
           return BoardItem(board);
         })}
         <BoardEnd>

--- a/client/src/pages/RegisterPage/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage/RegisterPage.tsx
@@ -82,7 +82,7 @@ const RegisterPage = () => {
 
   return (
     <>
-      <NormalTopBar />
+      <NormalTopBar buttonData={null} />
       <RegisterPageBody>
         <RegisterForm>
           <p className="wellcome-title">신규 유저님 환영합니다!</p>

--- a/client/src/static/addPost.svg
+++ b/client/src/static/addPost.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 15.9985V21.173C1 25.4461 2.047 27.1799 3.409 28.5882C4.819 29.9516 6.556 31 10.828 31H21.172C25.444 31 27.181 29.9501 28.591 28.5882C29.953 27.1799 31 25.4476 31 21.173V10.827C31 6.55394 29.953 4.81862 28.591 3.41026C27.181 2.0499 25.444 1 21.172 1H10.828C6.556 1 4.819 2.0484 3.409 3.41026C2.047 4.82012 1 6.55394 1 10.827V15.9985Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.81757 15.9999H24.1826" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.0045 7.81689V24.1803" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/types/responseData.ts
+++ b/client/src/types/responseData.ts
@@ -41,16 +41,22 @@ export interface NewPostApi extends Api {
 }
 
 export interface Board {
-  userId: number;
-  userName: string;
-  userProfile: string;
-  boardId: string;
+  id: string;
   content: string;
-  url: string[];
+  isStreet: boolean;
   like: number;
   comment: number;
   createAt: string;
   location: string | null;
+  // nextMaxId: number;
+  photos: {
+    url: string[];
+  };
+  user: {
+    id: number;
+    name: string;
+    profileUrl: string;
+  };
 }
 
 // 여기서 내부를 ? 처리한 이유는 500 에러가 난 경우를 대비한건가요?

--- a/client/src/types/responseData.ts
+++ b/client/src/types/responseData.ts
@@ -59,11 +59,20 @@ export interface Board {
   };
 }
 
-// 여기서 내부를 ? 처리한 이유는 500 에러가 난 경우를 대비한건가요?
 export interface BoardApi extends Api {
-  data: {
-    boards?: [Board];
-    nextMaxId?: number;
-    count?: number;
+  data?: {
+    boards: [Board];
+    nextMaxId: number;
+    count: number;
+  };
+}
+
+export interface LikeListApi extends Api {
+  data?: {
+    users: {
+      id: number;
+      name: string;
+      profileUrl: string;
+    };
   };
 }


### PR DESCRIPTION
Motivation :
- 홈 화면의 게시글에서 버튼 클릭에 대한 API 요청이나 해당 기능의 서비스 페이지로 이동할 수 있다.

Modifications:
- 댓글 아이콘 클릭시 Comment 페이지로 navigate
- 게시글 상단의 유저 정보 클릭시 해당 유저 페이지로 navigate
- 게시글 관련 API (BoardAPI) 작성
  - 게시글 수정
  - 게시글 삭제
  - 좋아요
  - 좋아요 취소
  - 좋아요 누른 사람들 목록 요청
- 현재 로그인된 계정의 게시글에 대해서만 수정/삭제가 가능하도록 버튼 활성화

Result:
- 댓글 창으로 이동이 가능하다.
- 유저 페이지로 이동이 가능하다.
- 내 게시글의 수정/삭제가 가능하다.

close #52 
관련 이슈 #42 #55 