### PR TITLE
[be/comment] 댓글 엔티티 모듈 및 등록, 조회 API 구현

### DIFF
--- a/server/src/board/board.entity.ts
+++ b/server/src/board/board.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { User } from '../user/user.entity';
 import { Photo } from './photo.entity';
+import { Comment } from 'src/comment/comment.entity';
 
 @Entity()
 export class Board {
@@ -33,10 +34,6 @@ export class Board {
   @Column({ nullable: true })
   like: number;
 
-  // Todo 연관관계 매핑필요
-  @Column({ nullable: true })
-  comment: number;
-
   @CreateDateColumn({
     type: 'timestamp',
   })
@@ -47,4 +44,7 @@ export class Board {
 
   @OneToMany(() => Photo, (photo) => photo.board)
   photos: Photo[];
+
+  @OneToMany(() => Comment, (comment) => comment.board)
+  comments: Comment[];
 }

--- a/server/src/comment/comment.controller.spec.ts
+++ b/server/src/comment/comment.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentController } from './comment.controller';
+
+describe('CommentController', () => {
+  let controller: CommentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentController],
+    }).compile();
+
+    controller = module.get<CommentController>(CommentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/server/src/comment/comment.controller.ts
+++ b/server/src/comment/comment.controller.ts
@@ -1,7 +1,7 @@
 import { Query } from '@nestjs/common';
 import { ValidationPipe } from '@nestjs/common';
 import { Body } from '@nestjs/common';
-import { Get, Post, Delete, Patch } from '@nestjs/common';
+import { Get, Post } from '@nestjs/common';
 import { Controller } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { GetCommentsDto } from './dto/get-comments.dto';
@@ -21,9 +21,9 @@ export class CommentController {
     return this.commentService.createComment(createCommentDto);
   }
 
-  @Delete('')
-  deleteComment() {}
+  // @Delete('')
+  // deleteComment() {}
 
-  @Patch('')
-  updateComment() {}
+  // @Patch('')
+  // updateComment() {}
 }

--- a/server/src/comment/comment.controller.ts
+++ b/server/src/comment/comment.controller.ts
@@ -1,0 +1,29 @@
+import { Query } from '@nestjs/common';
+import { ValidationPipe } from '@nestjs/common';
+import { Body } from '@nestjs/common';
+import { Get, Post, Delete, Patch } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
+import { CommentService } from './comment.service';
+import { GetCommentsDto } from './dto/get-comments.dto';
+import { CreateCommentDto } from './dto/create-comment.dto';
+
+@Controller('comment')
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @Get('')
+  getComments(@Query(new ValidationPipe()) getCommentsDto: GetCommentsDto) {
+    return this.commentService.getComments(getCommentsDto);
+  }
+
+  @Post('')
+  createComment(@Body() createCommentDto: CreateCommentDto) {
+    return this.commentService.createComment(createCommentDto);
+  }
+
+  @Delete('')
+  deleteComment() {}
+
+  @Patch('')
+  updateComment() {}
+}

--- a/server/src/comment/comment.entity.ts
+++ b/server/src/comment/comment.entity.ts
@@ -1,0 +1,37 @@
+import { Board } from 'board/board.entity';
+import { User } from 'src/user/user.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('comment')
+export class Comment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  content: string;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+  })
+  createAt: Date;
+
+  @ManyToOne(() => User, (user) => user.comments)
+  @JoinColumn()
+  user: User;
+
+  @ManyToOne(() => Board, (board) => board.comments)
+  @JoinColumn()
+  board: Board;
+
+  @OneToOne(() => Comment, (comment) => comment.rootComment)
+  @JoinColumn()
+  rootComment: Comment;
+}

--- a/server/src/comment/comment.module.ts
+++ b/server/src/comment/comment.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CommentController } from './comment.controller';
+import { Comment } from './comment.entity';
+import { CommentRepository } from './comment.repository';
+import { CommentService } from './comment.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment])],
+  controllers: [CommentController],
+  providers: [CommentService, CommentRepository],
+})
+export class CommentModule {}

--- a/server/src/comment/comment.repository.ts
+++ b/server/src/comment/comment.repository.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Comment } from './comment.entity';
+
+@Injectable()
+export class CommentRepository {
+  constructor(
+    @InjectRepository(Comment) private commentRepository: Repository<Comment>,
+  ) {}
+
+  async save(comment: Comment) {
+    await this.commentRepository.save(comment);
+  }
+
+  async findCommentListBy(boardId: number, count: number, maxId: number) {}
+}

--- a/server/src/comment/comment.repository.ts
+++ b/server/src/comment/comment.repository.ts
@@ -13,5 +13,43 @@ export class CommentRepository {
     await this.commentRepository.save(comment);
   }
 
-  async findCommentListBy(boardId: number, count: number, maxId: number) {}
+  async findCommentListBy(boardId: number, count: number, maxId: number) {
+    let results;
+
+    if (maxId == -1) {
+      results = await this.commentRepository
+        .createQueryBuilder('c')
+        .select(['c', 'u.id', 'u.name', 'u.profileUrl'])
+        .innerJoin('c.board', 'b')
+        .innerJoin('c.user', 'u')
+        .where('c.board_id = :id', { id: boardId })
+        .getMany();
+    } else {
+      results = await this.commentRepository
+        .createQueryBuilder('c')
+        .select(['c', 'u.id', 'u.name', 'u.profileUrl'])
+        .innerJoin('c.board', 'b')
+        .innerJoin('c.user', 'u')
+        .where('c.board_id = :id', { id: boardId })
+        .andWhere('c.id > :id', { id: maxId })
+        .getMany();
+    }
+
+    results = results.slice(0, count);
+    const _count = results.length;
+    const nestMaxId = results[_count - 1].id;
+
+    console.log(results);
+
+    return {
+      statusCode: 200,
+      message: 'Success',
+      data: {
+        comments: results,
+        board_id: boardId,
+        count: _count,
+        next_max_id: nestMaxId,
+      },
+    };
+  }
 }

--- a/server/src/comment/comment.service.spec.ts
+++ b/server/src/comment/comment.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentService } from './comment.service';
+
+describe('CommentService', () => {
+  let service: CommentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommentService],
+    }).compile();
+
+    service = module.get<CommentService>(CommentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/comment/comment.service.ts
+++ b/server/src/comment/comment.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { CommentRepository } from './comment.repository';
+import { GetCommentsDto } from './dto/get-comments.dto';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { Comment } from './comment.entity';
+import { plainToInstance } from 'class-transformer';
+
+@Injectable()
+export class CommentService {
+  constructor(private readonly commentRepository: CommentRepository) {}
+
+  async getComments(getCommentsDto: GetCommentsDto) {
+    const { boardId, count, max_id } = getCommentsDto;
+    return await this.commentRepository.findCommentListBy(
+      boardId,
+      count,
+      max_id,
+    );
+  }
+
+  async createComment(createCommentDto: CreateCommentDto) {
+    const { userId, content, boardId, rootCommentId } = createCommentDto;
+    const commentInfo = {
+      content: content,
+      user: userId,
+      board: boardId,
+      rootComment: rootCommentId,
+    };
+    const comment = plainToInstance(Comment, commentInfo);
+    await this.commentRepository.save(comment);
+
+    return {
+      statusCode: 201,
+      message: 'Success',
+      data: { commentId: comment.id },
+    };
+  }
+}

--- a/server/src/comment/comment.service.ts
+++ b/server/src/comment/comment.service.ts
@@ -10,9 +10,9 @@ export class CommentService {
   constructor(private readonly commentRepository: CommentRepository) {}
 
   async getComments(getCommentsDto: GetCommentsDto) {
-    const { boardId, count, max_id } = getCommentsDto;
+    const { board_id, count, max_id } = getCommentsDto;
     return await this.commentRepository.findCommentListBy(
-      boardId,
+      board_id,
       count,
       max_id,
     );

--- a/server/src/comment/dto/create-comment.dto.ts
+++ b/server/src/comment/dto/create-comment.dto.ts
@@ -1,0 +1,6 @@
+export class CreateCommentDto {
+  userId: number;
+  boardId: number;
+  content: string;
+  rootCommentId: null | number;
+}

--- a/server/src/comment/dto/get-comments.dto.ts
+++ b/server/src/comment/dto/get-comments.dto.ts
@@ -1,0 +1,13 @@
+import { int } from 'aws-sdk/clients/datapipeline';
+import { IsNotEmpty } from 'class-validator';
+
+export class GetCommentsDto {
+  @IsNotEmpty()
+  boardId: number;
+
+  @IsNotEmpty()
+  count: number;
+
+  @IsNotEmpty()
+  max_id: int;
+}

--- a/server/src/comment/dto/get-comments.dto.ts
+++ b/server/src/comment/dto/get-comments.dto.ts
@@ -3,7 +3,7 @@ import { IsNotEmpty } from 'class-validator';
 
 export class GetCommentsDto {
   @IsNotEmpty()
-  boardId: number;
+  board_id: number;
 
   @IsNotEmpty()
   count: number;

--- a/server/src/configs/typeorm.config.ts
+++ b/server/src/configs/typeorm.config.ts
@@ -4,6 +4,7 @@ import { User } from 'src/user/user.entity';
 import { Board } from '../board/board.entity';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { Photo } from 'board/photo.entity';
+import { Comment } from 'src/comment/comment.entity';
 
 dotenv.config();
 
@@ -14,7 +15,7 @@ export const typeORMConfig: TypeOrmModuleOptions = {
   username: process.env.DATABASE_USERNAME,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
-  entities: [User, Board, Photo],
+  entities: [User, Board, Photo, Comment],
   synchronize: true,
   namingStrategy: new SnakeNamingStrategy(),
 };

--- a/server/src/user/user.entity.ts
+++ b/server/src/user/user.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { OauthInfo } from '../auth/model/oauth-info.enum';
 import { Board } from '../board/board.entity';
+import { Comment } from 'src/comment/comment.entity';
 
 @Entity()
 export class User {
@@ -10,7 +11,7 @@ export class User {
   @Column({ unique: true })
   name: string;
 
-  @Column({ unique: true })
+  @Column()
   email: string;
 
   @Column()
@@ -21,4 +22,7 @@ export class User {
 
   @OneToMany(() => Board, (board) => board.user)
   boards: Board[];
+
+  @OneToMany(() => Comment, (comment) => comment.user)
+  comments: Comment[];
 }


### PR DESCRIPTION
Motivation :
- API 명세에 맞게 댓글을 등록하고 특정 게시글에 달린 댓글 리스트를 조회할 수 있도록 API를 작성함.

Modifications:
- 댓글 엔티티 모듈 생성
- 댓글 등록 API 작성
- 댓글 조회 API 작성

Result:
- api/comment 로 POST 요청 시 댓글이 DB에 저장됨
- api/comment?board_id=$ID&count=$COUNT&max_id=$MAX_ID 로 GET 요청시 댓글 리스트를 응답함
close #39 #46 #51