### PR TITLE
[fe/refactor hook] 스타일 코드 변경 및 custom hook 적용

### DIFF
--- a/client/src/apis/api/loginApi.ts
+++ b/client/src/apis/api/loginApi.ts
@@ -35,7 +35,7 @@ export const postRegisterInfo = async (
   email: string,
   userName: string,
   oauthInfo: 'NAVER' | 'KAKAO',
-  image?: File,
+  image: File | null,
 ): Promise<Api> => {
   const formData = new FormData();
   // TODO key 이름이 바뀔 수 있음

--- a/client/src/components/ImageSlot/ImageSlot.tsx
+++ b/client/src/components/ImageSlot/ImageSlot.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 // style
-import {
-  ImageSlotContainer,
-  ImageSlotDelBtn,
-  ImageSlotImage,
-} from './ImageSlotStyles';
+import S from './ImageSlotStyles';
 // image
 import delBtn from '../../static/delBtn.svg';
 
@@ -16,12 +12,12 @@ interface ImageSlotProps {
 
 const ImageSlot = ({ imgSrc, index, onClickFun }: ImageSlotProps) => {
   return (
-    <ImageSlotContainer className="preview-image-wrap">
-      <ImageSlotImage alt="preview" src={imgSrc} />
-      <ImageSlotDelBtn type="button" onClick={() => onClickFun(index)}>
+    <S.Container className="preview-image-wrap">
+      <S.Image alt="preview" src={imgSrc} />
+      <S.DeleteButton type="button" onClick={() => onClickFun(index)}>
         <img alt="delete button" src={delBtn} />
-      </ImageSlotDelBtn>
-    </ImageSlotContainer>
+      </S.DeleteButton>
+    </S.Container>
   );
 };
 

--- a/client/src/components/ImageSlot/ImageSlotStyles.tsx
+++ b/client/src/components/ImageSlot/ImageSlotStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const ImageSlotContainer = styled.div`
+const Container = styled.div`
   width: 4.75rem;
   height: 4.75rem;
   border-radius: 0.5rem;
@@ -8,14 +8,14 @@ const ImageSlotContainer = styled.div`
   flex: 0 0 auto;
 `;
 
-const ImageSlotImage = styled.img`
+const Image = styled.img`
   width: 4.75rem;
   height: 4.75rem;
   border: 1px solid ${(props) => props.theme.palette.border};
   border-radius: 0.5rem;
 `;
 
-const ImageSlotDelBtn = styled.button`
+const DeleteButton = styled.button`
   position: absolute;
   width: 1.625rem;
   height: 1.625rem;
@@ -32,4 +32,4 @@ const ImageSlotDelBtn = styled.button`
   }
 `;
 
-export { ImageSlotContainer, ImageSlotImage, ImageSlotDelBtn };
+export default { Container, Image, DeleteButton };

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -6,26 +6,26 @@ import mapIcon from '../../static/mapIcon.svg';
 import messageIcon from '../../static/messageIcon.svg';
 import userIcon from '../../static/userIcon.svg';
 // style
-import { NavBarContainer, NavBarIcon } from './NavBarStyles';
+import S from './NavBarStyles';
 
 const NavBar = () => {
   const navigation = useNavigate();
 
   return (
-    <NavBarContainer>
-      <NavBarIcon type="button" onClick={() => navigation('/home')}>
+    <S.Container>
+      <S.Icon type="button" onClick={() => navigation('/home')}>
         <img src={homeIcon} alt="Home" />
-      </NavBarIcon>
-      <NavBarIcon type="button">
+      </S.Icon>
+      <S.Icon type="button">
         <img src={mapIcon} alt="Home" />
-      </NavBarIcon>
-      <NavBarIcon type="button">
+      </S.Icon>
+      <S.Icon type="button">
         <img src={messageIcon} alt="Home" />
-      </NavBarIcon>
-      <NavBarIcon type="button">
+      </S.Icon>
+      <S.Icon type="button">
         <img src={userIcon} alt="Home" />
-      </NavBarIcon>
-    </NavBarContainer>
+      </S.Icon>
+    </S.Container>
   );
 };
 

--- a/client/src/components/NavBar/NavBarStyles.tsx
+++ b/client/src/components/NavBar/NavBarStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const NavBarContainer = styled.div`
+const Container = styled.div`
   width: 100%;
   height: 4rem;
   background-color: ${(props) => props.theme.palette.main};
@@ -15,7 +15,7 @@ const NavBarContainer = styled.div`
   bottom: 0;
 `;
 
-const NavBarIcon = styled.button`
+const Icon = styled.button`
   width: 2.25rem;
   height: 2.25rem;
   padding: 0px;
@@ -29,4 +29,4 @@ const NavBarIcon = styled.button`
   }
 `;
 
-export { NavBarContainer, NavBarIcon };
+export default { Container, Icon };

--- a/client/src/components/NormalTopBar/NormalTopBar.tsx
+++ b/client/src/components/NormalTopBar/NormalTopBar.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import logo from '../../static/whiteLogo.png';
 import appName from '../../static/logoName.png';
 
-const NoramlTopBarContainer = styled.div`
+const Container = styled.div`
   width: calc(100% - 24px);
   height: calc(4rem - 18px);
   background-color: ${(props) => props.theme.palette.main};
@@ -20,12 +20,13 @@ const NoramlTopBarContainer = styled.div`
   }
 `;
 
-const NormalTopBarLogoContainer = styled.div`
+const LogoContainer = styled.div`
   display: flex;
   justify-items: start;
   align-items: center;
   gap: 1rem;
 `;
+
 interface NormalTopBarProps {
   buttonData: {
     buttonImg: string;
@@ -37,21 +38,21 @@ interface NormalTopBarProps {
 const NormalTopBar = (props: NormalTopBarProps) => {
   const { buttonData } = props;
   return (
-    <NoramlTopBarContainer>
-      <NormalTopBarLogoContainer>
+    <Container>
+      <LogoContainer>
         <img src={logo} alt="Logo" style={{ width: '3rem', height: '3rem' }} />
         <img
           src={appName}
           alt="App Name"
           style={{ width: '10rem', height: '2rem' }}
         />
-      </NormalTopBarLogoContainer>
+      </LogoContainer>
       {buttonData !== null ? (
         <button type="button" onClick={buttonData.eventHandler}>
           <img src={buttonData.buttonImg} alt={buttonData.description} />
         </button>
       ) : null}
-    </NoramlTopBarContainer>
+    </Container>
   );
 };
 

--- a/client/src/components/TopBar/TopBar.tsx
+++ b/client/src/components/TopBar/TopBar.tsx
@@ -1,11 +1,7 @@
 /* eslint-disable react/require-default-props */
 import React, { MouseEventHandler } from 'react';
 // style
-import {
-  TopBarContainer,
-  TopBarBackButton,
-  TopBarCheckButton,
-} from './TopBarStyles';
+import S from './TopBarStyles';
 // img
 import backBtn from '../../static/backBtn.svg';
 import checkBtn from '../../static/checkBtn.svg';
@@ -28,27 +24,27 @@ const TopBar = ({
   checkDisableFunc,
 }: TopBarProps) => {
   return (
-    <TopBarContainer>
+    <S.Container>
       {isBack && backFunc ? (
-        <TopBarBackButton type="button" onClick={backFunc}>
+        <S.BackButton type="button" onClick={backFunc}>
           <img src={backBtn} alt="Back" />
-        </TopBarBackButton>
+        </S.BackButton>
       ) : (
         <div style={{ padding: '0.75rem' }} />
       )}
       <p>{title}</p>
       {isCheck && checkFunc && checkDisableFunc ? (
-        <TopBarCheckButton
+        <S.CheckButton
           type="button"
           onClick={checkFunc}
           disabled={checkDisableFunc()}
         >
           <img src={checkBtn} alt="Check" />
-        </TopBarCheckButton>
+        </S.CheckButton>
       ) : (
         <div style={{ padding: '0.75rem' }} />
       )}
-    </TopBarContainer>
+    </S.Container>
   );
 };
 

--- a/client/src/components/TopBar/TopBarStyles.tsx
+++ b/client/src/components/TopBar/TopBarStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const TopBarContainer = styled.div`
+const Container = styled.div`
   width: calc(100% - 24px);
   height: calc(4rem - 18px);
   background-color: ${(props) => props.theme.palette.main};
@@ -23,7 +23,7 @@ const TopBarContainer = styled.div`
   }
 `;
 
-const TopBarBackButton = styled.button`
+const BackButton = styled.button`
   width: 1.5rem;
   height: 1.5rem;
   border: none;
@@ -35,7 +35,7 @@ const TopBarBackButton = styled.button`
   }
 `;
 
-const TopBarCheckButton = styled.button`
+const CheckButton = styled.button`
   width: 1.5rem;
   height: 1.5rem;
   border: none;
@@ -61,4 +61,4 @@ const TopBarCheckButton = styled.button`
   }
 `;
 
-export { TopBarContainer, TopBarBackButton, TopBarCheckButton };
+export default { Container, BackButton, CheckButton };

--- a/client/src/hooks/useImage.ts
+++ b/client/src/hooks/useImage.ts
@@ -1,0 +1,32 @@
+import React, { useState, useCallback } from 'react';
+// type
+import Image from '../types/image';
+
+const useImage = (
+  init: Image,
+): {
+  image: Image;
+  onChangeImage: (event: React.ChangeEvent<HTMLInputElement>) => void;
+} => {
+  const [image, setImage] = useState<Image>(init);
+
+  const onChangeImage = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.currentTarget.files) {
+        const file = event.currentTarget.files;
+        setImage((prev) => ({ ...prev, image: file[0] }));
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const base64 = reader.result;
+          if (base64) setImage((prev) => ({ ...prev, image64: base64 }));
+        };
+        reader.readAsDataURL(file[0]);
+      }
+    },
+    [],
+  );
+
+  return { image, onChangeImage };
+};
+
+export default useImage;

--- a/client/src/hooks/useImage.ts
+++ b/client/src/hooks/useImage.ts
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 // type
-import Image from '../types/image';
+import { Image } from '../types/imageData';
 
 const useImage = (
   init: Image,

--- a/client/src/hooks/useImages.ts
+++ b/client/src/hooks/useImages.ts
@@ -1,0 +1,51 @@
+import React, { useState, useCallback } from 'react';
+// type
+import { Images } from '../types/imageData';
+
+const useImages = (
+  init: Images,
+): {
+  images: Images;
+  onChangeImage: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onDeleteImage: (index: number) => void;
+} => {
+  const [images, setImages] = useState<Images>(init);
+
+  const onChangeImage = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.currentTarget.files) {
+        Array.from(event.currentTarget.files).forEach((file) => {
+          if (images.images.length < 10)
+            setImages((prev) => {
+              const newImages = prev.images.concat(file);
+              return { ...prev, images: newImages };
+            });
+
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            const base64 = reader.result;
+            if (base64)
+              setImages((prev) => {
+                const newImages64 = prev.image64.concat(base64.toString());
+                return { ...prev, image64: newImages64 };
+              });
+          };
+          reader.readAsDataURL(file);
+        });
+      }
+    },
+    [],
+  );
+
+  const onDeleteImage = useCallback((index: number) => {
+    setImages((prev) => {
+      const newImages = prev.images.filter((_, idx) => idx !== index);
+      const newImages64 = prev.image64.filter((_, idx) => idx !== index);
+      return { images: newImages, image64: newImages64 };
+    });
+  }, []);
+
+  return { images, onChangeImage, onDeleteImage };
+};
+
+export default useImages;

--- a/client/src/hooks/useInputs.ts
+++ b/client/src/hooks/useInputs.ts
@@ -1,21 +1,30 @@
-import { useState, useCallback, ChangeEvent } from 'react';
+import React, { useState, useCallback, ChangeEvent } from 'react';
 
 const useInputs = <T>(
   initialForm: T,
 ): {
   form: T;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChangeForm: (
+    event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>,
+  ) => void;
+  setForm: React.Dispatch<React.SetStateAction<T>>;
   reset: () => void;
 } => {
   const [form, setForm] = useState<T>(initialForm);
 
-  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
-  }, []);
+  const onChangeForm = useCallback(
+    (
+      event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      const { name, value } = event.target;
+      setForm((prev) => ({ ...prev, [name]: value }));
+    },
+    [],
+  );
 
   const reset = useCallback(() => setForm(initialForm), []);
-  return { form, onChange, reset };
+
+  return { form, onChangeForm, setForm, reset };
 };
 
 export default useInputs;

--- a/client/src/hooks/useInputs.ts
+++ b/client/src/hooks/useInputs.ts
@@ -1,0 +1,21 @@
+import { useState, useCallback, ChangeEvent } from 'react';
+
+const useInputs = <T>(
+  initialForm: T,
+): {
+  form: T;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  reset: () => void;
+} => {
+  const [form, setForm] = useState<T>(initialForm);
+
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const reset = useCallback(() => setForm(initialForm), []);
+  return { form, onChange, reset };
+};
+
+export default useInputs;

--- a/client/src/pages/CommentPage/CommentPage.tsx
+++ b/client/src/pages/CommentPage/CommentPage.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { AxiosError } from 'axios';
-// recoil
 import { useRecoilValue } from 'recoil';
+// recoil
 import user from '../../store/userAtom';
 // api
 import { getCommentInfo, postCommentInfo } from '../../apis/api/commentApi';

--- a/client/src/pages/CommentPage/CommentPage.tsx
+++ b/client/src/pages/CommentPage/CommentPage.tsx
@@ -8,11 +8,7 @@ import user from '../../store/userAtom';
 // api
 import { getCommentInfo, postCommentInfo } from '../../apis/api/commentApi';
 // style
-import {
-  CommentPageBody,
-  CommentListContainer,
-  CommentPageStatus,
-} from './CommentPageStyles';
+import S from './CommentPageStyles';
 // component
 import TopBar from '../../components/TopBar/TopBar';
 import MessageForm from '../../components/MessageBox/MessageForm';
@@ -59,16 +55,16 @@ const CommentPage = () => {
         isCheck={false}
         backFunc={() => navigation(-1)}
       />
-      <CommentPageBody>
+      <S.Body>
         <MessageForm
           data={comment}
           onClickSendBtn={onClickSendBtn}
           setFunc={setComment}
         />
-        <CommentListContainer>
+        <S.Container>
           <div className="inner-container">
-            {isLoading && <CommentPageStatus>Loading...</CommentPageStatus>}
-            {isError && <CommentPageStatus>{error.message}</CommentPageStatus>}
+            {isLoading && <S.Status>Loading...</S.Status>}
+            {isError && <S.Status>{error.message}</S.Status>}
             {!(isError || isLoading) &&
               data &&
               data.map((commentData) => (
@@ -88,8 +84,8 @@ const CommentPage = () => {
                 />
               ))}
           </div>
-        </CommentListContainer>
-      </CommentPageBody>
+        </S.Container>
+      </S.Body>
       <NavBar />
     </>
   );

--- a/client/src/pages/CommentPage/CommentPageStyles.tsx
+++ b/client/src/pages/CommentPage/CommentPageStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const CommentPageBody = styled.div`
+const Body = styled.div`
   width: 100vw;
   height: calc(100vh - 10rem);
 
@@ -12,7 +12,7 @@ const CommentPageBody = styled.div`
   justify-content: space-between;
 `;
 
-const CommentListContainer = styled.div`
+const Container = styled.div`
   width: 90vw;
   height: calc((100vh - 10rem) / 10 * 8.5);
   background-color: ${(props) => props.theme.palette.inner};
@@ -37,7 +37,7 @@ const CommentListContainer = styled.div`
   }
 `;
 
-const CommentPageStatus = styled.p`
+const Status = styled.p`
   font-family: 'Jua';
   font-style: normal;
   font-weight: 400;
@@ -47,4 +47,4 @@ const CommentPageStatus = styled.p`
   margin: 5rem auto;
 `;
 
-export { CommentPageBody, CommentListContainer, CommentPageStatus };
+export default { Body, Container, Status };

--- a/client/src/pages/LoadingPage/LoadingPage.tsx
+++ b/client/src/pages/LoadingPage/LoadingPage.tsx
@@ -6,43 +6,50 @@ import user from '../../store/userAtom';
 // api
 import { postAuthInfo } from '../../apis/api/loginApi';
 // style
-import { Background, LoadingText } from './LoadingPageStyles';
+import S from './LoadingPageStyles';
 // img
 import loadingCat from '../../static/loadingCat.gif';
+import { LoginApi } from '../../types/responseData';
+
+const getSocialName = (url: URL): 'naver' | 'kakao' | undefined => {
+  const callback = url.pathname.split('/')[2];
+  if (callback.includes('naver')) return 'naver';
+  if (callback.includes('kakao')) return 'kakao';
+  return undefined;
+};
 
 const LoadingPage = () => {
   const navigation = useNavigate();
-
   const setUserData = useSetRecoilState(user);
 
-  const getSocialName = (url: URL): 'naver' | 'kakao' => {
-    const callback = url.pathname.split('/')[2];
-    let name: 'naver' | 'kakao' = 'kakao';
-    if (callback.includes('naver')) name = 'naver';
-    return name;
-  };
-
-  // TODO 여기 너무 else 덩어리인 것 같음
   const postAuthrizationInfo = async (
     socialName: 'naver' | 'kakao',
     authorizationCode: string,
     state: string,
   ) => {
+    let data: LoginApi;
     try {
-      const data = await postAuthInfo(socialName, authorizationCode, state);
-      if (data.statusCode !== 200) navigation('/');
-      else if (data.redirect)
+      data = await postAuthInfo(socialName, authorizationCode, state);
+      // 서버 에러인 경우를 먼저 처리한다.
+      if (data.statusCode !== 200) {
+        navigation('/');
+        return;
+      }
+      // 회원 가입인 경우를 처리한다.
+      if (data.redirect) {
         navigation('/register', {
           state: { email: data.email, oauthInfo: 'NAVER' },
         });
-      else if (data.data) {
-        // eslint-disable-next-line no-console
-        console.log(data.data);
+        return;
+      }
+      // 로그인 성공인 경우를 처리한다.
+      if (data.data) {
         setUserData({ userId: data.data.userId });
-        // eslint-disable-next-line no-console
-        console.log(data.data);
         navigation('/home');
-      } else navigation('/');
+        return;
+      }
+      // 그 외의 경우를 처리한다.
+      navigation('/');
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error);
@@ -53,18 +60,19 @@ const LoadingPage = () => {
     const url = new URL(window.location.href);
     const authorizationCode = url.searchParams.get('code');
     const state = url.searchParams.get('state');
-    // TODO 만약에 여기서 getSocialName 에 아무것도 없다면 ? (인위적으로 클라이언트가 입력)
     if (authorizationCode && state) {
       const socialName = getSocialName(url);
-      postAuthrizationInfo(socialName, authorizationCode, state);
+      if (socialName)
+        postAuthrizationInfo(socialName, authorizationCode, state);
+      else navigation('/');
     }
   }, []);
 
   return (
-    <Background>
+    <S.Body>
       <img src={loadingCat} alt="로딩중" width="30%" />
-      <LoadingText>Loading...</LoadingText>
-    </Background>
+      <S.Text>Loading...</S.Text>
+    </S.Body>
   );
 };
 

--- a/client/src/pages/LoadingPage/LoadingPageStyles.tsx
+++ b/client/src/pages/LoadingPage/LoadingPageStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const Background = styled.div`
+const Body = styled.div`
   position: absolute;
   width: 100vw;
   height: 100vh;
@@ -14,7 +14,8 @@ const Background = styled.div`
   justify-content: center;
 `;
 
-const LoadingText = styled.div`
+const Text = styled.p`
+  margin: 0px;
   padding-top: 5%;
   font-family: 'Jua';
   font-style: normal;
@@ -22,4 +23,4 @@ const LoadingText = styled.div`
   font-size: 18px;
 `;
 
-export { Background, LoadingText };
+export default { Body, Text };

--- a/client/src/pages/LoginPage/LoginPage.tsx
+++ b/client/src/pages/LoginPage/LoginPage.tsx
@@ -1,36 +1,36 @@
 import React from 'react';
 // style
-import { LoginPageContainer, OauthButton } from './LoginPageStyles';
+import S from './LoginPageStyles';
 // img
 import logo from '../../static/whiteLogo.png';
 import appName from '../../static/logoName.png';
 import kakaoOauth from '../../static/kakao_oauth.png';
 import naverOauth from '../../static/naver_oauth.png';
 
-const LoginPage = () => {
-  const onClickNaverLogin = () => {
-    const clientId = process.env.REACT_APP_NAVER_LOGIN_CLIENT_ID;
-    const stateString = process.env.REACT_APP_NAVER_LOGIN_STATE;
-    const callbackUrl = process.env.REACT_APP_NAVER_LOGIN_CALLBACK_URL;
-    const naverLoginUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${clientId}&state=${stateString}&redirect_uri=${callbackUrl}`;
-    window.location.assign(naverLoginUrl);
-  };
+const onClickNaverLogin = () => {
+  const clientId = process.env.REACT_APP_NAVER_LOGIN_CLIENT_ID;
+  const stateString = process.env.REACT_APP_NAVER_LOGIN_STATE;
+  const callbackUrl = process.env.REACT_APP_NAVER_LOGIN_CALLBACK_URL;
+  const naverLoginUrl = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${clientId}&state=${stateString}&redirect_uri=${callbackUrl}`;
+  window.location.assign(naverLoginUrl);
+};
 
+const LoginPage = () => {
   return (
-    <LoginPageContainer>
+    <S.Container>
       <img alt="Logo" src={logo} style={{ width: '5rem', height: '5rem' }} />
       <img
         alt="App Name"
         src={appName}
         style={{ width: '16rem', height: '3.5rem', marginBottom: '20px' }}
       />
-      <OauthButton type="button" onClick={onClickNaverLogin}>
+      <S.OauthButton type="button" onClick={onClickNaverLogin}>
         <img alt="Naver Oauth" src={naverOauth} />
-      </OauthButton>
-      <OauthButton type="button">
+      </S.OauthButton>
+      <S.OauthButton type="button">
         <img alt="Kakao Oauth" src={kakaoOauth} />
-      </OauthButton>
-    </LoginPageContainer>
+      </S.OauthButton>
+    </S.Container>
   );
 };
 

--- a/client/src/pages/LoginPage/LoginPageStyles.tsx
+++ b/client/src/pages/LoginPage/LoginPageStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const LoginPageContainer = styled.div`
+const Container = styled.div`
   height: 100vh;
   width: 100vw;
   display: flex;
@@ -22,4 +22,4 @@ const OauthButton = styled.button`
   }
 `;
 
-export { LoginPageContainer, OauthButton };
+export default { Container, OauthButton };

--- a/client/src/pages/NewPostPage/NewPostPageStyles.tsx
+++ b/client/src/pages/NewPostPage/NewPostPageStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const NewPostFrom = styled.form`
+const Form = styled.form`
   width: calc(100% - 2rem);
   height: calc(100vh - 10rem);
   display: flex;
@@ -15,7 +15,7 @@ const NewPostFrom = styled.form`
   font-weight: 400;
 `;
 
-const NewPostImageContainer = styled.div`
+const ImageContainer = styled.div`
   display: flex;
   flex-direction: row;
   height: 5.5rem;
@@ -44,7 +44,7 @@ const NewPostImageContainer = styled.div`
   }
 `;
 
-const NewPostCategoryButton = styled.button<{ checked: boolean }>`
+const CategoryButton = styled.button<{ checked: boolean }>`
   width: 8rem;
   height: 2rem;
   border-radius: 0.5rem;
@@ -60,7 +60,7 @@ const NewPostCategoryButton = styled.button<{ checked: boolean }>`
     props.checked ? props.theme.palette.main : '#d8d8d8'};
 `;
 
-const NewPostTextarea = styled.textarea`
+const Textarea = styled.textarea`
   width: calc(100% - 3rem);
   height: 10rem;
   background-color: ${(props) => props.theme.palette.back};
@@ -77,9 +77,4 @@ const NewPostTextarea = styled.textarea`
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
 `;
 
-export {
-  NewPostFrom,
-  NewPostImageContainer,
-  NewPostCategoryButton,
-  NewPostTextarea,
-};
+export default { Form, ImageContainer, CategoryButton, Textarea };

--- a/client/src/pages/RegisterPage/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage/RegisterPage.tsx
@@ -3,16 +3,14 @@ import { useNavigate, useLocation } from 'react-router-dom';
 // api
 import { postRegisterInfo } from '../../apis/api/loginApi';
 // style
-import {
-  RegisterPageBody,
-  RegisterForm,
-  ImageSlot,
-} from './RegisterPageStyles';
+import S from './RegisterPageStyles';
 // img
 import defaultProfile from '../../static/defaultProfile.svg';
 import plusBtn from '../../static/plusBtn.svg';
 // component
 import NormalTopBar from '../../components/NormalTopBar/NormalTopBar';
+// hook
+import useImage from '../../hooks/useImage';
 
 type LocationStateType = { email: string; oauthInfo: 'NAVER' | 'KAKAO' };
 
@@ -24,12 +22,12 @@ const RegisterPage = () => {
     : { email: '', oauthInfo: 'NAVER' };
 
   const profileImageBtn = useRef<HTMLInputElement>(null);
-  const registerBtn = useRef<HTMLButtonElement>(null);
 
-  const [profileImage, setProfileImage] = useState<File>();
-  const [base64Image, setBase64Image] = useState<string | ArrayBuffer>(
-    defaultProfile,
-  );
+  const { image, onChangeImage } = useImage({
+    image: null,
+    image64: defaultProfile,
+  });
+
   const [nickname, setNickname] = useState<string>('');
 
   useEffect(() => {
@@ -42,21 +40,6 @@ const RegisterPage = () => {
     }
   };
 
-  const onChangeProfileImage = (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ): void => {
-    if (event.currentTarget.files) {
-      const file = event.currentTarget.files;
-      setProfileImage(file[0]);
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const base64 = reader.result;
-        if (base64) setBase64Image(base64);
-      };
-      reader.readAsDataURL(file[0]);
-    }
-  };
-
   const onChangeNickname = (event: React.ChangeEvent<HTMLInputElement>) =>
     setNickname(event.target.value);
 
@@ -66,9 +49,8 @@ const RegisterPage = () => {
         email,
         nickname,
         oauthInfo,
-        profileImage,
+        image.image,
       );
-      // 일단 회원가입 하고 다시 홈으로 보내자 그냥
       if (data.statusCode === 201) navigate('/');
       // TODO 아닌 경우 처리 (닉네임이 중복인 경우, 일반적인 실패)
       // eslint-disable-next-line no-alert
@@ -82,18 +64,18 @@ const RegisterPage = () => {
   return (
     <>
       <NormalTopBar buttonData={null} />
-      <RegisterPageBody>
-        <RegisterForm>
+      <S.Body>
+        <S.Form>
           <p className="wellcome-title">신규 유저님 환영합니다!</p>
           <p className="wellcome-info">유저님의 추가 정보를 작성해주세요!</p>
-          <ImageSlot>
-            <img src={base64Image as string} alt="Slot" />
+          <S.ProfileContainer>
+            <img src={image.image64 as string} alt="Slot" />
             <input
               type="file"
               accept="image/*"
               style={{ display: 'none' }}
               ref={profileImageBtn}
-              onChange={onChangeProfileImage}
+              onChange={onChangeImage}
             />
             <button
               className="input-button"
@@ -102,7 +84,7 @@ const RegisterPage = () => {
             >
               <img src={plusBtn} alt="Add" />
             </button>
-          </ImageSlot>
+          </S.ProfileContainer>
           <input
             className="nickname-input"
             type="text"
@@ -110,16 +92,15 @@ const RegisterPage = () => {
             onChange={onChangeNickname}
           />
           <button
-            ref={registerBtn}
             className="submit-button"
             type="button"
             onClick={onClickRegisterBtn}
-            disabled={!nickname || !profileImage}
+            disabled={!nickname}
           >
             회원가입
           </button>
-        </RegisterForm>
-      </RegisterPageBody>
+        </S.Form>
+      </S.Body>
     </>
   );
 };

--- a/client/src/pages/RegisterPage/RegisterPageStyles.tsx
+++ b/client/src/pages/RegisterPage/RegisterPageStyles.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const RegisterPageBody = styled.div`
+const Body = styled.div`
   width: 100%;
   height: calc(100vh - 4rem);
   display: flex;
@@ -13,7 +13,7 @@ const RegisterPageBody = styled.div`
   font-weight: 400;
 `;
 
-const RegisterForm = styled.form`
+const Form = styled.form`
   width: 17rem;
   height: 27rem;
   background: ${(props) => props.theme.palette.inner};
@@ -83,7 +83,7 @@ const RegisterForm = styled.form`
   }
 `;
 
-const ImageSlot = styled.div`
+const ProfileContainer = styled.div`
   width: 6rem;
   height: 6rem;
   position: relative;
@@ -116,4 +116,4 @@ const ImageSlot = styled.div`
   }
 `;
 
-export { RegisterPageBody, RegisterForm, ImageSlot };
+export default { Body, Form, ProfileContainer };

--- a/client/src/types/image.ts
+++ b/client/src/types/image.ts
@@ -1,0 +1,6 @@
+interface Image {
+  image: File | null;
+  image64: string | ArrayBuffer;
+}
+
+export default Image;

--- a/client/src/types/image.ts
+++ b/client/src/types/image.ts
@@ -1,6 +1,0 @@
-interface Image {
-  image: File | null;
-  image64: string | ArrayBuffer;
-}
-
-export default Image;

--- a/client/src/types/imageData.ts
+++ b/client/src/types/imageData.ts
@@ -1,0 +1,9 @@
+export interface Image {
+  image: File | null;
+  image64: string | ArrayBuffer;
+}
+
+export interface Images {
+  images: File[];
+  image64: string[];
+}

--- a/client/src/types/responseData.ts
+++ b/client/src/types/responseData.ts
@@ -37,7 +37,7 @@ export interface NewCommentApi extends Api {
 }
 
 export interface NewPostApi extends Api {
-  data: {
+  data?: {
     boardId: number;
   };
 }


### PR DESCRIPTION
Motivation:
- 스타일 코드 관련 조은님의 질문을 보면서 저렇게 하면 어떨까 하는 생각이 들었다.
  - 지금은 스타일 코드 파일에서 따로따로 이름을 지어서 넘기는데 이렇게 하니 import 부분이 너무 길어지고 이름을 간결하게 하고 싶은데 그렇지 못하는 경우가 많았다.
  - 이를 해소하기 위해서 스타일 파일에서 이름을 간결하게 가져가고 import 할 때 크게 S 객체로 받아서 내부 속성들로 이용하면 어떨까? 라는 생각을 했다.

- custom hook 을 이전부터 적용해보고 싶었는데 미뤄만 두고 있었다. 이번 기회에 프로젝트 규모가 더 커지기 전에 컴포넌트가 다루는 것에 집중 할 수 있도록 custom hook 을 통해서 세부적인 기능을 분할하고 이를 통해서 컴포넌트 내부 코드를 간결하게 가져가고 싶었다.

Modifications: 
- custom hook
  - 단일 이미지, 복수 이미지, 폼 인풋 관련해서 3개의 custom hook 생성

- NormalTopBar, TopBar, ImageSlot, NavBar 스타일 코드 변경

- Loading, Login, Comment 페이지 관련
  - Component 내부에 있지 않아도 괜찮은 함수를 밖으로 빼 재생성이 안되도록 했다.
  - 스타일 코드 변경
 
- Register 페이지 관련
  - custom hook 을 적용한 코드 정리
 
- NewPost 페이지 관련
  - custom hook 을 적용한 코드 정리

Result: 
- 각 페이지 컴포넌트의 코드가 조금 간결해졌고 이벤트와 dom 생성에 관련된 내용 위주로 담게 바뀌었다.
- styled-components 관련 이름들이 조금은 간단해지고 어떠한 역할인지 보기 쉬워졌으나 앞으로 이를 더 적용할지 팀과의 이야기가 필요하다.