### PR TITLE
[fe/board] 게시글 버그 수정 및 기능 추가

### DIFF
--- a/client/src/components/BoardItem/BoardBody/BoardBody.tsx
+++ b/client/src/components/BoardItem/BoardBody/BoardBody.tsx
@@ -17,11 +17,11 @@ interface BoardBodyProps {
   content: string;
   like: number;
   comment: number;
-  createAt: string;
+  createdAt: string;
 }
 
 const BoardBody = (props: BoardBodyProps) => {
-  const { boardId, content, like, comment, createAt } = props;
+  const { boardId, content, like, comment, createdAt } = props;
   const navigate = useNavigate();
 
   const onClickCommentIcon = () => {
@@ -54,7 +54,7 @@ const BoardBody = (props: BoardBodyProps) => {
             {like > 0 ? <p>좋아요 {like}개</p> : ''}
             {comment > 0 ? <p>댓글 {comment}개</p> : ''}
           </div>
-          <p>{timeCalc(createAt)}</p>
+          <p>{timeCalc(createdAt)}</p>
         </BoardBodyInfoContainer>
       </BoardBodyContainer>
     </BoardBodyWrapper>

--- a/client/src/components/BoardItem/BoardBody/BoardBody.tsx
+++ b/client/src/components/BoardItem/BoardBody/BoardBody.tsx
@@ -10,6 +10,7 @@ import {
 import likeButton from '../../../static/emptyHeart.svg';
 // import alreadyLikeButton from '../../../static/filledHeart.svg';
 import commentButton from '../../../static/commentBtn.svg';
+import timeCalc from '../../../utils/timeCalc';
 
 interface BoardBodyProps {
   boardId: string;
@@ -53,7 +54,7 @@ const BoardBody = (props: BoardBodyProps) => {
             {like > 0 ? <p>좋아요 {like}개</p> : ''}
             {comment > 0 ? <p>댓글 {comment}개</p> : ''}
           </div>
-          <p>{createAt}</p>
+          <p>{timeCalc(createAt)}</p>
         </BoardBodyInfoContainer>
       </BoardBodyContainer>
     </BoardBodyWrapper>

--- a/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
+++ b/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
@@ -66,7 +66,6 @@ const BoardHeader = (props: BoardHeaderProps) => {
       const data = await deleteBoardData(boardId, userId);
       if (data.statusCode === 200) {
         setMenuHideOption(!menuHideOption);
-        /* TODO: 나중에 개인 페이지에서 삭제할 경우 경로 설정 필요 */
         window.location.replace('/home');
       }
     } catch (error) {
@@ -76,7 +75,6 @@ const BoardHeader = (props: BoardHeaderProps) => {
   };
 
   const onClickUserInfo = () => {
-    /* TODO: 해당 유저 페이지로 이동 */
     navigation(`/user/${userName}`, { state: { targetId: userId } });
   };
   return (
@@ -102,9 +100,7 @@ const BoardHeader = (props: BoardHeaderProps) => {
             )}
           </BoardHeaderInfoContainer>
         </BoardHeaderContainer>
-        {/* // 현재 로그인한 계정의 게시글만 수정/삭제할 수 있도록 함
-        {loginedUserId === userId ? ( */}
-        {loginedUserId !== null ? ( // 테스트용
+        {loginedUserId === userId ? (
           <button type="button" onClick={onClickMenu}>
             <img src={menuButton} alt="Create/Delete DropDown" />
           </button>

--- a/client/src/components/BoardItem/BoardItem.tsx
+++ b/client/src/components/BoardItem/BoardItem.tsx
@@ -15,7 +15,7 @@ const convertPhotosToUrls = (photos: { url: string }[]) => {
 };
 
 const BoardItem = (props: Board) => {
-  if (props === undefined) return null;
+  if (props === undefined || props === null) return null;
 
   const {
     id,

--- a/client/src/components/BoardItem/BoardItem.tsx
+++ b/client/src/components/BoardItem/BoardItem.tsx
@@ -23,7 +23,7 @@ const BoardItem = (props: Board) => {
     isStreet,
     like,
     comment,
-    createAt,
+    createdAt,
     location,
     photos,
     user,
@@ -45,7 +45,7 @@ const BoardItem = (props: Board) => {
         content={content}
         like={like}
         comment={comment}
-        createAt={createAt}
+        createAt={createdAt}
       />
     </BoardBackground>
   );

--- a/client/src/components/BoardItem/BoardItem.tsx
+++ b/client/src/components/BoardItem/BoardItem.tsx
@@ -45,7 +45,7 @@ const BoardItem = (props: Board) => {
         content={content}
         like={like}
         comment={comment}
-        createAt={createdAt}
+        createdAt={createdAt}
       />
     </BoardBackground>
   );

--- a/client/src/components/ImageCarousel/ImageCarousel.tsx
+++ b/client/src/components/ImageCarousel/ImageCarousel.tsx
@@ -8,7 +8,7 @@ import CarouselItem from './CarouselItem/CarouselItem';
 
 const CarouselWrapper = styled.div`
   width: 85vw;
-  height: 85vw;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/client/src/types/responseData.ts
+++ b/client/src/types/responseData.ts
@@ -56,7 +56,7 @@ export interface Board {
   isStreet: boolean;
   like: number;
   comment: number;
-  createAt: string;
+  createdAt: string;
   location: string | '';
   coordinate: number[];
   photos: {


### PR DESCRIPTION
### Motivation :
- 이미지 캐러셀에서 세로가 긴 이미지가 인풋으로 들어오는 경우, viewport width로 이미지 세로 크기가 설정되어 지정한 크기 안에 이미지가 담기지 않는 버그가 존재했다.
- 게시글 컴포넌트인 BoardItem에 props가 null로 들어오는 경우가 존재한다.
- 게시글이 언제 추가되었는지 표시되지 않아 시간순으로 보이는지 알 수가 없다.
- 이전에는 테스트 버전으로 모든 게시글에 대해 모든 유저가 수정/삭제가 가능하도록 설정하였지만, 자신의 게시글만 수정/삭제할 수 있도록 수정하였다.

### Modifications:
- 캐러셀의 세로 이미지 크기를 vw가 아닌 %로 바꾸어 해결하였다.
- BoardItem에서 props가 null인 경우 예외 처리하였다. (원인 파악이 필요할 것 같다.)
- timeCalc 함수로 생성시간을 parsing하여 게시글에 표시되도록 하였다.
- 현재 로그인된 아이디와 게시글 작성자의 아이디가 일치하는 경우에만 게시글 메뉴 버튼을 렌더링하도록 하였다.

### Result:
- 이미지 캐러셀이 정상 작동한다.
- 게시글이 없더라도 에러가 발생하지 않는다.
- 게시글이 업로드된 시간이 표시된다.
- 내가 작성한 게시글에 대해서만 수정/삭제가 가능하다.

close #124  #126 
