### PR TITLE
[fe/modify_user] 유저 페이지 정보 수정 페이지 추가 및 기능 연결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,7 +40,7 @@ const App = () => {
             <Route path="/comment/:boardId" element={<CommentPage />} />
             <Route path="/new-post" element={<NewPostPage />} />
             <Route path="/modify" element={<ModifyPage />} />
-            <Route path="/user/:userName" element={<UserPage />} />
+            <Route path="/user/:userName/:targetId" element={<UserPage />} />
             <Route path="/modify-user" element={<ModifyUserPage />} />
             <Route path="/follow/:userName/:userId" element={<FollowPage />} />
             <Route path="/map" element={<MapPage />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import ModifyPage from './pages/ModifyPage/ModifyPage';
 import UserPage from './pages/UserPage/UserPage';
 import FollowPage from './pages/FollowPage/FollowPage';
 import MapPage from './pages/MapPage/MapPage';
+import ModifyUserPage from './pages/ModifyUserPage/ModifyUserPage';
 
 const queryClient = new QueryClient();
 
@@ -40,6 +41,7 @@ const App = () => {
             <Route path="/new-post" element={<NewPostPage />} />
             <Route path="/modify" element={<ModifyPage />} />
             <Route path="/user/:userName" element={<UserPage />} />
+            <Route path="/modify-user" element={<ModifyUserPage />} />
             <Route path="/follow/:userName/:userId" element={<FollowPage />} />
             <Route path="/map" element={<MapPage />} />
           </Routes>

--- a/client/src/apis/api/userApi.ts
+++ b/client/src/apis/api/userApi.ts
@@ -5,7 +5,7 @@ import {
   UserInfoApi,
   UserPostApi,
 } from '../../types/responseData';
-import { defaultInstance } from '../utils';
+import { defaultInstance, defaultFormInstance } from '../utils';
 // type
 
 const getUserInfo = async (
@@ -57,4 +57,44 @@ const getFollow = async (userId: number): Promise<FollowListApi> => {
   return data;
 };
 
-export { getUserInfo, getUserPost, postFollow, deleteFollow, getFollow };
+const patchUserInfo = async (
+  userId: number,
+  userName: string,
+  image: File | null,
+): Promise<Api> => {
+  const formData = new FormData();
+  formData.append('userId', String(userId));
+  formData.append('userName', userName);
+  formData.append('image', image || '');
+
+  const { data }: AxiosResponse<Api> = await defaultFormInstance.patch(
+    `/api/user/info`,
+    formData,
+  );
+  return data;
+};
+
+const putUserImage = async (
+  userId: number,
+  image: File | null,
+): Promise<Api> => {
+  const formData = new FormData();
+  formData.append('userId', String(userId));
+  formData.append('image', image || '');
+
+  const { data }: AxiosResponse<Api> = await defaultFormInstance.patch(
+    `/api/user/image`,
+    formData,
+  );
+  return data;
+};
+
+export {
+  getUserInfo,
+  getUserPost,
+  postFollow,
+  deleteFollow,
+  getFollow,
+  patchUserInfo,
+  putUserImage,
+};

--- a/client/src/apis/utils/index.ts
+++ b/client/src/apis/utils/index.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { SERVER, TESTSERVER } from '../config';
 
 // SERVER 연결시 SERVER 로 변경 / 테스트시 TESTSERVER 로 변경
-const BASE_URL = SERVER;
+const BASE_URL = TESTSERVER;
 
 const axiosApi = (url: string, headers?: Record<string, unknown>) => {
   return axios.create({ baseURL: url, headers });

--- a/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
+++ b/client/src/components/BoardItem/BoardHeader/BoardHeader.tsx
@@ -75,7 +75,7 @@ const BoardHeader = (props: BoardHeaderProps) => {
   };
 
   const onClickUserInfo = () => {
-    navigation(`/user/${userName}`, { state: { targetId: userId } });
+    navigation(`/user/${userName}/${userId}`);
   };
   return (
     <>

--- a/client/src/components/MenuModal/MenuModal.tsx
+++ b/client/src/components/MenuModal/MenuModal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/require-default-props */
 import React, { useRef, useEffect } from 'react';
 // style
 import MenuModalContainer from './MenuModalStyles';
@@ -6,8 +7,10 @@ interface MenuModalProps {
   top: number;
   left: number;
   onClickCancel: () => void;
-  onClickModify: () => void;
-  onClickDelete: () => void;
+  onClickModify?: () => void;
+  onClickDelete?: () => void;
+  isCantModify?: boolean;
+  isCantDelete?: boolean;
 }
 
 const MenuModal = ({
@@ -16,6 +19,8 @@ const MenuModal = ({
   onClickCancel,
   onClickModify,
   onClickDelete,
+  isCantModify,
+  isCantDelete,
 }: MenuModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -37,12 +42,16 @@ const MenuModal = ({
 
   return (
     <MenuModalContainer top={top} left={left} ref={modalRef}>
-      <button type="button" onClick={onClickModify}>
-        수정하기
-      </button>
-      <button type="button" onClick={onClickDelete}>
-        삭제하기
-      </button>
+      {!isCantModify && (
+        <button type="button" onClick={onClickModify}>
+          수정하기
+        </button>
+      )}
+      {!isCantDelete && (
+        <button type="button" onClick={onClickDelete}>
+          삭제하기
+        </button>
+      )}
       <button type="button" onClick={onClickCancel}>
         취소
       </button>

--- a/client/src/components/NavBar/NavBar.tsx
+++ b/client/src/components/NavBar/NavBar.tsx
@@ -29,9 +29,7 @@ const NavBar = () => {
       <S.Icon
         type="button"
         onClick={() =>
-          navigation(`/user/${userData.userName}`, {
-            state: { targetId: userData.userId },
-          })
+          navigation(`/user/${userData.userName}/${userData.userId}`)
         }
       >
         <img src={userIcon} alt="User" />

--- a/client/src/components/ProfileIcon/ProfileIcon.tsx
+++ b/client/src/components/ProfileIcon/ProfileIcon.tsx
@@ -37,7 +37,7 @@ const ProfileIcon = ({
   return (
     <ProfileIconContainer
       type="button"
-      onClick={() => navigation(`/user/${userName}`, { state: { targetId } })}
+      onClick={() => navigation(`/user/${userName}/${targetId}`)}
       customLength={customLength || 2.5}
     >
       <img src={userProfile} alt="Profile" />

--- a/client/src/components/UserInfoContainer/UserInfoContainer.tsx
+++ b/client/src/components/UserInfoContainer/UserInfoContainer.tsx
@@ -1,24 +1,31 @@
 /* eslint-disable no-console */
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { AxiosError } from 'axios';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 // recoil
 import user from '../../store/userAtom';
+import userProfile from '../../store/userProfileAtom';
 // api
 import { getUserInfo, postFollow, deleteFollow } from '../../apis/api/userApi';
 // style
 import S from './UserInfoContainerStyles';
 // component
 import ProfileIcon from '../ProfileIcon/ProfileIcon';
+import MenuModal from '../MenuModal/MenuModal';
+// type
 import { Api, UserInfo } from '../../types/responseData';
+// img
+import menuBtn from '../../static/menuBtn.svg';
 
 const UserInfoContainer = ({ targetId }: { targetId: number }) => {
   const navigation = useNavigate();
   const queryClient = useQueryClient();
 
   const { userId } = useRecoilValue(user);
+  const setProfile = useSetRecoilState(userProfile);
+  const [modalOn, setModalOn] = useState<boolean>(false);
 
   const userInfo = useQuery<UserInfo, AxiosError>('userInfo', () =>
     getUserInfo(targetId, userId).then((res) => res.data),
@@ -67,6 +74,11 @@ const UserInfoContainer = ({ targetId }: { targetId: number }) => {
     else postFol();
   };
 
+  const onClickModifyBtn = () => {
+    setProfile(userInfo.data.userProfileUrl || '../../defaultProfile.svg');
+    navigation('/modify-user');
+  };
+
   return (
     <>
       <S.OuterContainer>
@@ -98,6 +110,20 @@ const UserInfoContainer = ({ targetId }: { targetId: number }) => {
               <p>팔로잉</p>
             </S.CountSlot>
           </S.InnerContainer>
+          {userId === targetId && (
+            <S.MenuBtn type="button" onClick={() => setModalOn(true)}>
+              <img src={menuBtn} alt="Menu" />
+            </S.MenuBtn>
+          )}
+          {modalOn && (
+            <MenuModal
+              top={20}
+              left={60}
+              onClickCancel={() => setModalOn(false)}
+              onClickModify={onClickModifyBtn}
+              isCantDelete
+            />
+          )}
         </S.InnerContainerWrap>
       </S.OuterContainer>
       {targetId !== userId && (

--- a/client/src/components/UserInfoContainer/UserInfoContainerStyles.tsx
+++ b/client/src/components/UserInfoContainer/UserInfoContainerStyles.tsx
@@ -31,6 +31,7 @@ const OuterContainer = styled.div`
 `;
 
 const InnerContainerWrap = styled.div`
+  position: relative;
   width: 70%;
   height: 100%;
 `;
@@ -112,6 +113,21 @@ const DMButton = styled.button`
   padding: 0px;
 `;
 
+const MenuBtn = styled.button`
+  position: absolute;
+  right: 0.4rem;
+  top: 0.4rem;
+  padding: 0px;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
 export default {
   StatusWrap,
   OuterContainer,
@@ -122,4 +138,5 @@ export default {
   ButtonContainer,
   FollowButton,
   DMButton,
+  MenuBtn,
 };

--- a/client/src/pages/ModifyUserPage/ModifyUserPage.tsx
+++ b/client/src/pages/ModifyUserPage/ModifyUserPage.tsx
@@ -77,7 +77,7 @@ const ModifyUserPage = () => {
       if (userName !== nickname)
         data = await patchUserInfo(userId, nickname, image.image);
       else data = await putUserImage(userId, image.image);
-      if (data.statusCode === 200) navigation(`/user/${nickname}`);
+      if (data.statusCode === 200) navigation(`/user/${nickname}/${userId}`);
       // eslint-disable-next-line no-alert
       else alert(data.message);
     } catch (error) {

--- a/client/src/pages/ModifyUserPage/ModifyUserPage.tsx
+++ b/client/src/pages/ModifyUserPage/ModifyUserPage.tsx
@@ -1,0 +1,143 @@
+import React, { useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+// recoil
+import user from '../../store/userAtom';
+import userProfile from '../../store/userProfileAtom';
+// style
+import S from './ModifyUserPageStyles';
+// hook
+import useImage from '../../hooks/useImage';
+// api
+import { postNameCheck } from '../../apis/api/loginApi';
+import { putUserImage, patchUserInfo } from '../../apis/api/userApi';
+// img
+import defaultProfile from '../../static/defaultProfile.svg';
+import plusBtn from '../../static/plusBtn.svg';
+// component
+import TopBar from '../../components/TopBar/TopBar';
+import { Api } from '../../types/responseData';
+
+const ModifyUserPage = () => {
+  const navigation = useNavigate();
+
+  const { userId, userName } = useRecoilValue(user);
+  const profile = useRecoilValue(userProfile);
+  const profileImageBtn = useRef<HTMLInputElement>(null);
+  const { image, onChangeImage } = useImage({
+    image: null,
+    image64: profile || defaultProfile,
+  });
+  const [nickname, setNickname] = useState<string>(userName);
+  const [nameCheck, setNameCheck] = useState<boolean>(true);
+  const [nameCheckP, setNameCheckP] = useState<string>(
+    '기존 별명은 그대로 사용 가능합니다.',
+  );
+
+  const onClickProfileImageBtn = () => {
+    if (profileImageBtn.current) {
+      profileImageBtn.current.click();
+    }
+  };
+
+  const onChangeNickname = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(event.target.value);
+    if (nameCheck) {
+      setNameCheck(false);
+      setNameCheckP('별명 중복 체크를 해주세요.');
+    }
+  };
+
+  const onClickNameChekcBtn = async () => {
+    if (nameCheck) return;
+    if (userName === nickname) {
+      setNameCheck(true);
+      setNameCheckP('기존 별명은 그대로 사용 가능합니다.');
+      return;
+    }
+    try {
+      const data = await postNameCheck(nickname);
+      if (data.statusCode === 200) {
+        setNameCheck(!data.data.isExist);
+        setNameCheckP(
+          data.data.isExist
+            ? '이미 존재하는 별명입니다.'
+            : '사용 가능한 별명입니다.',
+        );
+      } else setNameCheckP(data.message);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  };
+
+  const onClickModifyBtn = async () => {
+    try {
+      let data: Api;
+      if (userName !== nickname)
+        data = await patchUserInfo(userId, nickname, image.image);
+      else data = await putUserImage(userId, image.image);
+      if (data.statusCode === 200) navigation(`/user/${nickname}`);
+      // eslint-disable-next-line no-alert
+      else alert(data.message);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  };
+
+  return (
+    <>
+      <TopBar
+        isBack
+        title={userName}
+        isCheck={false}
+        backFunc={() => navigation(-1)}
+      />
+      <S.Body>
+        <S.Form>
+          <S.Title>유저 수정 페이지다냥!</S.Title>
+          <S.Info>사진과 닉네임 변경이 가능하다냥!</S.Info>
+          <S.ProfileContainer>
+            <img src={image.image64 as string} alt="Slot" />
+            <input
+              type="file"
+              accept="image/*"
+              style={{ display: 'none' }}
+              ref={profileImageBtn}
+              onChange={onChangeImage}
+            />
+            <button type="button" onClick={onClickProfileImageBtn}>
+              <img src={plusBtn} alt="Add" />
+            </button>
+          </S.ProfileContainer>
+          <S.InputContainer>
+            <S.Input
+              type="text"
+              value={nickname}
+              placeholder="바꿀 별명은 무엇인가냥?"
+              onChange={onChangeNickname}
+            />
+            <S.NameCheckButton
+              type="button"
+              onClick={onClickNameChekcBtn}
+              checked={nameCheck}
+            >
+              중복 체크
+            </S.NameCheckButton>
+          </S.InputContainer>
+          <p>{nameCheckP}</p>
+          <S.SubmitButton
+            type="button"
+            onClick={onClickModifyBtn}
+            disabled={!nickname || !nameCheck}
+          >
+            정보수정
+          </S.SubmitButton>
+        </S.Form>
+      </S.Body>
+    </>
+  );
+};
+
+export default ModifyUserPage;

--- a/client/src/pages/ModifyUserPage/ModifyUserPageStyles.tsx
+++ b/client/src/pages/ModifyUserPage/ModifyUserPageStyles.tsx
@@ -1,0 +1,155 @@
+import styled from 'styled-components';
+
+const Body = styled.div`
+  width: 100%;
+  height: calc(100vh - 4rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${(props) => props.theme.palette.back};
+
+  font-family: 'Jua';
+  font-style: normal;
+  font-weight: 400;
+`;
+
+const Form = styled.form`
+  width: 17rem;
+  height: 27rem;
+  background: ${(props) => props.theme.palette.inner};
+  border: 1px solid ${(props) => props.theme.palette.border};
+  border-radius: 35px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  gap: 20px;
+
+  padding: 52px 49px 32px 49px;
+
+  * {
+    font-family: 'Jua';
+    font-style: normal;
+    font-weight: 400;
+  }
+`;
+
+const Title = styled.p`
+  margin: 0px;
+  font-size: 30px;
+  line-height: 38px;
+`;
+
+const Info = styled.p`
+  margin: 0px;
+  font-size: 20px;
+  line-height: 25px;
+`;
+
+const InputContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-items: center;
+  align-items: center;
+
+  width: 100%;
+  gap: 1rem;
+`;
+
+const NameCheckButton = styled.button<{ checked: boolean }>`
+  cursor: pointer;
+  border: none;
+  padding: 0px;
+
+  width: 30%;
+  height: 2rem;
+  background: ${(props) =>
+    props.checked ? '#3ae048' : props.theme.palette.border};
+  color: ${(props) => (props.checked ? '#ffffff' : '#000000')};
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 0.625rem;
+
+  font-size: 16px;
+  line-height: 20px;
+`;
+
+const Input = styled.input`
+  width: 65%;
+  height: 3rem;
+  border-radius: 1rem;
+  background-color: ${(props) => props.theme.palette.back};
+  border: 1px solid ${(props) => props.theme.palette.border};
+  padding: 0px 10px;
+
+  cursor: pointer;
+
+  &::placeholder {
+    font-size: 15px;
+    line-height: 19px;
+    color: #9b9b9b;
+  }
+`;
+const SubmitButton = styled.button`
+  width: 9.5rem;
+  height: 3rem;
+  background: ${(props) => props.theme.palette.main};
+  color: #ffffff;
+  border: 1px solid ${(props) => props.theme.palette.border};
+  border-radius: 1rem;
+  font-size: 20px;
+  line-height: 25px;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+
+  cursor: pointer;
+
+  &:disabled {
+    background-color: #d4d4d4;
+    color: #000000;
+  }
+`;
+
+const ProfileContainer = styled.div`
+  width: 6rem;
+  height: 6rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${(props) => props.theme.palette.back};
+  border: 1px solid ${(props) => props.theme.palette.border};
+  border-radius: 3rem;
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 3rem;
+  }
+
+  Button {
+    position: absolute;
+    top: 4rem;
+    left: 4rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #bcc7ff;
+    border: 1px solid ${(props) => props.theme.palette.border};
+    border-radius: 1.25rem;
+    cursor: pointer;
+  }
+`;
+
+export default {
+  Body,
+  Form,
+  ProfileContainer,
+  Title,
+  Info,
+  NameCheckButton,
+  InputContainer,
+  Input,
+  SubmitButton,
+};

--- a/client/src/pages/RegisterPage/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage/RegisterPage.tsx
@@ -56,6 +56,7 @@ const RegisterPage = () => {
   };
 
   const onClickNameChekcBtn = async () => {
+    if (nameCheck) return;
     try {
       const data = await postNameCheck(nickname);
       if (data.statusCode === 200) {

--- a/client/src/pages/UserPage/UserPage.tsx
+++ b/client/src/pages/UserPage/UserPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 // recoil
 import user from '../../store/userAtom';
@@ -13,23 +13,24 @@ import UserPostContainer from '../../components/UserPostContainer/UserPostContai
 
 // TODO 리엑트 쿼리로 받아온 것에 대해서 계속 undefind 를 고려해야 한다.
 const UserPage = () => {
-  const location = useLocation();
   const navigation = useNavigate();
-  const { targetId } = location.state;
-  const { userName } = useParams<{ userName: string }>();
+  const { userName, targetId } = useParams<{
+    userName: string;
+    targetId: string;
+  }>();
   const { userId } = useRecoilValue(user);
 
   return (
     <>
       <TopBar
-        isBack={userId !== targetId}
+        isBack={userId !== Number(targetId)}
         title={userName || 'error'}
         isCheck={false}
         backFunc={() => navigation(-1)}
       />
       <S.Body>
-        <UserInfoContainer targetId={targetId} />
-        <UserPostContainer targetId={targetId} />
+        <UserInfoContainer targetId={Number(targetId)} />
+        <UserPostContainer targetId={Number(targetId)} />
       </S.Body>
       <NavBar />
     </>

--- a/client/src/store/userProfileAtom.ts
+++ b/client/src/store/userProfileAtom.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+const userProfile = atom({
+  key: 'userProfile',
+  default: '',
+});
+
+export default userProfile;


### PR DESCRIPTION
### Motivation :
- 유저 페이지에서 사용자의 개인 정보를 수정하기 위한 페이지가 별도로 필요하다.

### Modifications:
- 기본적으로 회원가입 페이지와 동일한 UI 로 구성했다.
- 본인의 유저 페이지인 경우 메뉴 버튼이 나오며 누르면 모달이 생긴다. 
  - 이 부분에서 모달 컴포넌트에 props 를 추가했다. 필수 props 는 아니며 삭제하기와 수정하기를 표시하지 않게 할 수 있는 props 이다.
- 이후 상세 페이지에서 사진과 별명을 변경할 수 있다.
- 만약 성공하게 된다면 본인의 유저페이지로 돌아간다.

### Result:
- 유저 수정 페이지 기능 생성 완료 및 서버 테스트 필요

close #82
