### PR TITLE
[fe/detail_page] 유저 게시글 클릭시 상세 페이지 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import UserPage from './pages/UserPage/UserPage';
 import FollowPage from './pages/FollowPage/FollowPage';
 import MapPage from './pages/MapPage/MapPage';
 import ModifyUserPage from './pages/ModifyUserPage/ModifyUserPage';
+import BoardDetailPage from './pages/BoardDetailPage/BoardDetailPage';
 
 const queryClient = new QueryClient();
 
@@ -44,6 +45,7 @@ const App = () => {
             <Route path="/modify-user" element={<ModifyUserPage />} />
             <Route path="/follow/:userName/:userId" element={<FollowPage />} />
             <Route path="/map" element={<MapPage />} />
+            <Route path="/detail" element={<BoardDetailPage />} />
           </Routes>
         </QueryClientProvider>
       </RecoilRoot>

--- a/client/src/apis/api/userApi.ts
+++ b/client/src/apis/api/userApi.ts
@@ -50,9 +50,12 @@ const deleteFollow = async (
   return data;
 };
 
-const getFollow = async (userId: number): Promise<FollowListApi> => {
+const getFollow = async (
+  userId: number,
+  viewerId: number,
+): Promise<FollowListApi> => {
   const { data }: AxiosResponse<FollowListApi> = await defaultInstance.get(
-    `/api/user/follow/${userId}`,
+    `/api/user/follow/${userId}?viewer=${viewerId}`,
   );
   return data;
 };

--- a/client/src/apis/utils/index.ts
+++ b/client/src/apis/utils/index.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { SERVER, TESTSERVER } from '../config';
 
 // SERVER 연결시 SERVER 로 변경 / 테스트시 TESTSERVER 로 변경
-const BASE_URL = TESTSERVER;
+const BASE_URL = SERVER;
 
 const axiosApi = (url: string, headers?: Record<string, unknown>) => {
   return axios.create({ baseURL: url, headers });

--- a/client/src/components/BoardItem/BoardItemStyles.tsx
+++ b/client/src/components/BoardItem/BoardItemStyles.tsx
@@ -12,6 +12,9 @@ const BoardBackground = styled.div`
   flex-direction: column;
   align-items: center;
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+
+  font-family: 'Jua';
+  font-style: normal;
 `;
 
 export default BoardBackground;

--- a/client/src/components/FollowContainer/FollowContainer.tsx
+++ b/client/src/components/FollowContainer/FollowContainer.tsx
@@ -23,7 +23,7 @@ const FollowContainer = ({ userId }: FollowerContainerProps) => {
   const [status, setStatus] = useState<boolean>(true);
 
   const followList = useQuery<FollowListData, AxiosError>('followList', () =>
-    getFollow(Number(userId)).then((res) => res.data),
+    getFollow(Number(userId), viewerId).then((res) => res.data),
   );
 
   const onClickFollowerBtn = () => setStatus(true);
@@ -80,7 +80,7 @@ const FollowContainer = ({ userId }: FollowerContainerProps) => {
           ? followList.data.users_follow_user.map((followUser) => (
               <FollowUnit
                 key={followUser.id}
-                userId={userId}
+                userId={viewerId}
                 targetId={followUser.id}
                 userName={followUser.name}
                 isFollow={followUser.is_followed_by_viewer}
@@ -90,7 +90,7 @@ const FollowContainer = ({ userId }: FollowerContainerProps) => {
           : followList.data.users_followed_by_user.map((followedUser) => (
               <FollowUnit
                 key={followedUser.id}
-                userId={userId}
+                userId={viewerId}
                 targetId={followedUser.id}
                 userName={followedUser.name}
                 isFollow={followedUser.is_followed_by_viewer}

--- a/client/src/components/UserPostContainer/UserPostContainer.tsx
+++ b/client/src/components/UserPostContainer/UserPostContainer.tsx
@@ -44,15 +44,16 @@ const UserPostContainer = ({ targetId }: { targetId: number }) => {
 
   return (
     <S.Grid>
-      {boards.map((board) => (
-        <S.GridSlot
-          key={board.id}
-          type="button"
-          onClick={() => onClickThumbnail(board)}
-        >
-          <img alt="Thumbnail" src={board.photos[0].url} />
-        </S.GridSlot>
-      ))}
+      {boards &&
+        boards.map((board) => (
+          <S.GridSlot
+            key={board.id}
+            type="button"
+            onClick={() => onClickThumbnail(board)}
+          >
+            <img alt="Thumbnail" src={board.photos[0].url} />
+          </S.GridSlot>
+        ))}
     </S.Grid>
   );
 };

--- a/client/src/components/UserPostContainer/UserPostContainer.tsx
+++ b/client/src/components/UserPostContainer/UserPostContainer.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
+import { useSetRecoilState } from 'recoil';
+import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'react-query';
 import { AxiosError } from 'axios';
+// recoil
+import boardDetail from '../../store/boardDetailAtom';
 // api
 import { getUserPost } from '../../apis/api/userApi';
 // style
 import S from './UserPostContainerStyles';
 // component
-import { UserPostApi } from '../../types/responseData';
+import { Board, UserPostApi } from '../../types/responseData';
 
 const UserPostContainer = ({ targetId }: { targetId: number }) => {
+  const navigation = useNavigate();
+  const setBoardDetail = useSetRecoilState(boardDetail);
   const userPost = useQuery<UserPostApi, AxiosError>('userPost', () =>
     getUserPost(targetId),
   );
@@ -31,10 +37,19 @@ const UserPostContainer = ({ targetId }: { targetId: number }) => {
 
   const { boards } = userPost.data.data;
 
+  const onClickThumbnail = (board: Board) => {
+    setBoardDetail(board);
+    navigation('/detail');
+  };
+
   return (
     <S.Grid>
       {boards.map((board) => (
-        <S.GridSlot key={board.id} type="button">
+        <S.GridSlot
+          key={board.id}
+          type="button"
+          onClick={() => onClickThumbnail(board)}
+        >
           <img alt="Thumbnail" src={board.photos[0].url} />
         </S.GridSlot>
       ))}

--- a/client/src/pages/BoardDetailPage/BoardDetailPage.tsx
+++ b/client/src/pages/BoardDetailPage/BoardDetailPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { useNavigate } from 'react-router-dom';
+
+import S from './BoardDetailPageStyles';
+import boardDetail from '../../store/boardDetailAtom';
+import NavBar from '../../components/NavBar/NavBar';
+import TopBar from '../../components/TopBar/TopBar';
+import BoardItem from '../../components/BoardItem/BoardItem';
+
+const BoardDetailPage = () => {
+  const navigation = useNavigate();
+  const boardData = useRecoilValue(boardDetail);
+
+  return (
+    <>
+      <TopBar
+        isBack
+        title="상세페이지"
+        isCheck={false}
+        backFunc={() => navigation(-1)}
+      />
+      <S.Wrap>{BoardItem(boardData)}</S.Wrap>
+      <NavBar />
+    </>
+  );
+};
+
+export default BoardDetailPage;

--- a/client/src/pages/BoardDetailPage/BoardDetailPageStyles.tsx
+++ b/client/src/pages/BoardDetailPage/BoardDetailPageStyles.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const Wrap = styled.div`
+  font-family: 'Jua';
+  font-style: normal;
+  min-height: 100vh;
+  overflow: hidden;
+  width: 100vw;
+  height: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export default { Wrap };

--- a/client/src/pages/BoardDetailPage/BoardDetailPageStyles.tsx
+++ b/client/src/pages/BoardDetailPage/BoardDetailPageStyles.tsx
@@ -3,10 +3,10 @@ import styled from 'styled-components';
 const Wrap = styled.div`
   font-family: 'Jua';
   font-style: normal;
-  min-height: 100vh;
   overflow: hidden;
   width: 100vw;
   height: 90%;
+  min-height: calc(100vh - 4rem);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/client/src/pages/ModifyUserPage/ModifyUserPage.tsx
+++ b/client/src/pages/ModifyUserPage/ModifyUserPage.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 // recoil
 import user from '../../store/userAtom';
@@ -21,7 +21,7 @@ import { Api } from '../../types/responseData';
 const ModifyUserPage = () => {
   const navigation = useNavigate();
 
-  const { userId, userName } = useRecoilValue(user);
+  const [{ userId, userName }, setUserInfo] = useRecoilState(user);
   const profile = useRecoilValue(userProfile);
   const profileImageBtn = useRef<HTMLInputElement>(null);
   const { image, onChangeImage } = useImage({
@@ -77,7 +77,10 @@ const ModifyUserPage = () => {
       if (userName !== nickname)
         data = await patchUserInfo(userId, nickname, image.image);
       else data = await putUserImage(userId, image.image);
-      if (data.statusCode === 200) navigation(`/user/${nickname}/${userId}`);
+      if (data.statusCode === 200) {
+        setUserInfo((prev) => ({ userId: prev.userId, userName: nickname }));
+        navigation(`/user/${nickname}/${userId}`);
+      }
       // eslint-disable-next-line no-alert
       else alert(data.message);
     } catch (error) {

--- a/client/src/store/boardDetailAtom.ts
+++ b/client/src/store/boardDetailAtom.ts
@@ -1,0 +1,24 @@
+import { atom } from 'recoil';
+import { Board } from '../types/responseData';
+
+const boardDetail = atom<Board>({
+  key: 'boardDetail',
+  default: {
+    id: '-1',
+    content: '',
+    isStreet: false,
+    like: 0,
+    comment: 0,
+    createdAt: '',
+    location: '',
+    coordinate: [0, 0],
+    photos: [{ url: '' }],
+    user: {
+      id: 0,
+      name: '',
+      profileUrl: '',
+    },
+  },
+});
+
+export default boardDetail;

--- a/client/src/store/userProfileAtom.ts
+++ b/client/src/store/userProfileAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
-const userProfile = atom({
+const userProfile = atom<string>({
   key: 'userProfile',
   default: '',
 });

--- a/client/src/types/responseData.ts
+++ b/client/src/types/responseData.ts
@@ -106,28 +106,9 @@ export interface UserInfoApi extends Api {
   data: UserInfo;
 }
 
-// TODO 보드 관련 인터페이스가 두개인게 이거 일을 반복하는 일 같음
-
-export interface UserPost {
-  id: string;
-  content: string;
-  isStreet: boolean;
-  location: string | null;
-  latitude: number;
-  longitude: number;
-  like: number;
-  created_at: string;
-  photos: [{ url: string }];
-  user: {
-    id: number;
-    name: string;
-    profileUrl: string;
-  };
-}
-
 export interface UserPostApi extends Api {
   data: {
-    boards: [UserPost];
+    boards: [Board];
     count: number;
     next_max_id: number;
   };

--- a/server/src/user/follow/follow.repository.ts
+++ b/server/src/user/follow/follow.repository.ts
@@ -33,8 +33,8 @@ export class FollowRepository {
 
   async findFollowing(userId: number, viewerId: number) {
     return await this.followRepository.query(
-      `SELECT FOLLOWS.*, ISNULL(followed_user_Id) AS is_followed_by_viewer FROM\
-      (SELECT user.id, user.name, user.profile_url FROM follow LEFT JOIN user ON user.id = follow.followed_user_id WHERE follow.user_id=${userId}) AS FOLLOWS\
+      `SELECT follows.*, ISNULL(followed_user_Id) AS is_followed_by_viewer FROM\
+      (SELECT user.id, user.name, user.profile_url FROM follow LEFT JOIN user ON user.id = follow.followed_user_id WHERE follow.user_id=${userId}) AS follows\
       LEFT JOIN (SELECT followed_user_Id FROM follow WHERE follow.user_id=${viewerId}) AS sub ON sub.followed_user_id = follows.id;`,
     );
   }
@@ -43,9 +43,9 @@ export class FollowRepository {
 
   async findFollower(userId: number, viewerId: number) {
     return await this.followRepository
-      .query(`SELECT FOLLOWS.*, ISNULL(followed_user_Id) AS is_followed_by_viewer\
-       FROM (SELECT user.id, user.name, user.profile_url FROM follow LEFT JOIN user ON user.id=follow.user_id WHERE followed_user_id=${userId}) AS FOLLOWS\
-       LEFT JOIN (SELECT followed_user_Id FROM follow WHERE follow.user_id=${viewerId}) AS sub ON sub.followed_user_id = FOLLOWS.id;`);
+      .query(`SELECT followers.*, ISNULL(followed_user_Id) AS is_followed_by_viewer\
+      FROM (SELECT user.id, user.name, user.profile_url FROM follow LEFT JOIN user ON user.id=follow.user_id WHERE followed_user_id=${userId}) AS followers\
+      LEFT JOIN (SELECT followed_user_Id FROM follow WHERE follow.user_id=${viewerId}) AS sub ON sub.followed_user_id = followers.id;`);
   }
 
   async findFollowingCnt(userId: number) {


### PR DESCRIPTION
### Motivation :
- 유저 프로필에 있는 게시글 그리드의 글을 누를 때 해당 글만 볼 수 있는 상세 페이지를 제공해야한다.

### Modifications:
- 유저 상세 페이지 UI 추가 및 상세페이지 이벤트 연결
  - 상세 페이지로 이동할 경우 필요한 데이터를 유저 게시글 데이터에서 recoil 을 통해서 전달한다. 
- BoardItem 글꼴 적용
- 상세페이지 라우팅 연결
- 유저 정보 수정 페이지에서 recoil 유저 데이터 set 이 누락됬는데, 해당 이슈 해결

### Result:
- 유저 페이지에서 포스트를 누르면 해당 포스트로 이동하며 이후 덧글이나 게시글 관련 이벤트도 잘 동작한다.
- 발견한 다른 이슈
  - 팔로우 관련 서버응답에 오류가 있다.
  - local storage 만 생각해서 로그인 생략(유지) 기능을 만들었는데 서버가 꺼지고 redis 정보가 날라가면 다른 서비스 이용이 안된다.
    - 이를 해결하기 위해서 home 화면 혹은 다른 화면에서 unauthorized 에러가 날라왔을 경우를 처리하거나 세션 로그인 과정을 조금 수정해야 한다.   

close #90 
