### PR TITLE
[fe/map update] 지도 영역 변경시 timeout 이후 데이터 요청 및 지도 페이지 리팩토링

### DIFF
--- a/client/src/constants/map.ts
+++ b/client/src/constants/map.ts
@@ -1,0 +1,6 @@
+export const LOCATION_1784 = {
+  latitude: 37.3595953,
+  longitude: 127.1053971,
+};
+
+export const WAIT_TIME_BEFORE_REQUEST = 600;

--- a/client/src/hooks/useCurrentLocation.ts
+++ b/client/src/hooks/useCurrentLocation.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { LOCATION_1784 } from '../constants/map';
+import { Coordinate } from '../utils/map/map';
+
+const useCurrentLocation = () => {
+  const [currentLocation, setCurrentLocation] =
+    useState<Coordinate>(LOCATION_1784);
+
+  useEffect(() => {
+    if (window.navigator.geolocation) {
+      window.navigator.geolocation.getCurrentPosition((position) => {
+        setCurrentLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        });
+      });
+    }
+  }, []);
+
+  return currentLocation;
+};
+
+export default useCurrentLocation;

--- a/client/src/pages/MapPage/MapPage.tsx
+++ b/client/src/pages/MapPage/MapPage.tsx
@@ -40,6 +40,8 @@ const LOCATION1784 = {
   longitude: 127.1053971,
 };
 
+const waitTimeBeforeRequest = 600;
+
 const MapPage = () => {
   const navigation = useNavigate();
   const { naver } = window;
@@ -98,7 +100,11 @@ const MapPage = () => {
     if (map === null) return;
 
     naver.maps.Event.addListener(map, 'dragend', () => {
-      requestData();
+      const { x: currentX, y: currentY } = map.getCenter();
+      setTimeout(() => {
+        const { x: newX, y: newY } = map.getCenter();
+        if (currentX === newX && currentY === newY) requestData();
+      }, waitTimeBeforeRequest);
     });
   }, [map]);
 

--- a/client/src/pages/MapPage/MapPage.tsx
+++ b/client/src/pages/MapPage/MapPage.tsx
@@ -17,6 +17,7 @@ import { NaverMap, SpinnerWrapper, Spinner } from './MapPageStyles';
 import NormalTopBar from '../../components/NormalTopBar/NormalTopBar';
 import NavBar from '../../components/NavBar/NavBar';
 import BoardModal from '../../components/BoardModal/BoardModal';
+import { LOCATION_1784, WAIT_TIME_BEFORE_REQUEST } from '../../constants/map';
 
 declare global {
   interface Window {
@@ -34,13 +35,6 @@ interface QueryRange {
     longitude: number;
   };
 }
-
-const LOCATION1784 = {
-  latitude: 37.3595953,
-  longitude: 127.1053971,
-};
-
-const waitTimeBeforeRequest = 600;
 
 const MapPage = () => {
   const navigation = useNavigate();
@@ -87,7 +81,7 @@ const MapPage = () => {
 
   /* 사용자 현재 위치 가져오기 */
   useEffect(() => {
-    const naverMap = NaverMapModule.createMap(LOCATION1784);
+    const naverMap = NaverMapModule.createMap(LOCATION_1784);
     setMap(naverMap);
 
     if (window.navigator.geolocation) {
@@ -107,11 +101,11 @@ const MapPage = () => {
     if (map === null) return;
 
     naver.maps.Event.addListener(map, 'dragend', () => {
-      requestAfterTimeout(map, waitTimeBeforeRequest);
+      requestAfterTimeout(map, WAIT_TIME_BEFORE_REQUEST);
     });
 
     naver.maps.Event.addListener(map, 'zoom_changed', () => {
-      requestAfterTimeout(map, waitTimeBeforeRequest);
+      requestAfterTimeout(map, WAIT_TIME_BEFORE_REQUEST);
     });
   }, [map]);
 

--- a/client/src/pages/MapPage/MapPage.tsx
+++ b/client/src/pages/MapPage/MapPage.tsx
@@ -17,7 +17,10 @@ import { NaverMap, SpinnerWrapper, Spinner } from './MapPageStyles';
 import NormalTopBar from '../../components/NormalTopBar/NormalTopBar';
 import NavBar from '../../components/NavBar/NavBar';
 import BoardModal from '../../components/BoardModal/BoardModal';
+// constant
 import { LOCATION_1784, WAIT_TIME_BEFORE_REQUEST } from '../../constants/map';
+// hook
+import useCurrentLocation from '../../hooks/useCurrentLocation';
 
 declare global {
   interface Window {
@@ -39,9 +42,7 @@ interface QueryRange {
 const MapPage = () => {
   const navigation = useNavigate();
   const { naver } = window;
-  const [currentLocation, setCurrentLocation] = useState<
-    { latitude: number; longitude: number } | string
-  >('');
+  const currentLocation = useCurrentLocation();
   const [map, setMap] = useState<naver.maps.Map | null>(null);
   const [boards, setBoards] = useState<Board[]>([]);
   const [clickedBoard, setClickedBoard] = useState<Board | null>(null);
@@ -79,22 +80,9 @@ const MapPage = () => {
     }, timeout);
   };
 
-  /* 사용자 현재 위치 가져오기 */
   useEffect(() => {
     const naverMap = NaverMapModule.createMap(LOCATION_1784);
     setMap(naverMap);
-
-    if (window.navigator.geolocation) {
-      window.navigator.geolocation.getCurrentPosition((position) => {
-        setCurrentLocation({
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-        });
-      });
-    } else {
-      // eslint-disable-next-line
-      window.alert('현재 위치를 알 수 없습니다.');
-    }
   }, []);
 
   useEffect(() => {

--- a/client/src/pages/NewPostPage/NewPostPage.tsx
+++ b/client/src/pages/NewPostPage/NewPostPage.tsx
@@ -15,6 +15,7 @@ import getlocationData from '../../apis/services/reverseGeocodingService';
 // hook
 import useImages from '../../hooks/useImages';
 import useInputs from '../../hooks/useInputs';
+import useCurrentLocation from '../../hooks/useCurrentLocation';
 // style
 import S from './NewPostPageStyles';
 // img
@@ -30,6 +31,7 @@ interface PostData {
 const NewPostPage = () => {
   const imgInput = useRef<HTMLInputElement>(null);
   const navigation = useNavigate();
+  const currentLocation = useCurrentLocation();
 
   const userData = useRecoilValue(user);
   const { images, onChangeImage, onDeleteImage } = useImages({
@@ -50,22 +52,21 @@ const NewPostPage = () => {
 
   // TODO 안눌렀을 경우 체크
   const findLocation = async () => {
-    if (location.isChecked || !navigator.geolocation) return;
-    navigator.geolocation.getCurrentPosition(async (position) => {
-      const { latitude, longitude } = position.coords;
-      try {
-        const reverseGeo = await getlocationData(latitude, longitude);
-        setLocation({
-          isChecked: true,
-          latitude,
-          longitude,
-          location: reverseGeo,
-        });
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log(error);
-      }
-    });
+    if (location.isChecked) return;
+
+    const { latitude, longitude } = currentLocation;
+    try {
+      const reverseGeo = await getlocationData(latitude, longitude);
+      setLocation({
+        isChecked: true,
+        latitude,
+        longitude,
+        location: reverseGeo,
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
   };
 
   const onClickSubmitBtn = async () => {

--- a/client/src/utils/map/naverMap.ts
+++ b/client/src/utils/map/naverMap.ts
@@ -39,11 +39,9 @@ const hideMarker = (map: naver.maps.Map, marker: naver.maps.Marker) => {
 };
 
 const hideAllMarker = (map: naver.maps.Map, markers: naver.maps.Marker[]) => {
-  let marker;
-  for (let i = 0; i < markers.length; i += 1) {
-    marker = markers[i];
+  markers.forEach((marker) => {
     hideMarker(map, marker);
-  }
+  });
 };
 
 const updateMarkers = (map: naver.maps.Map, markers: naver.maps.Marker[]) => {

--- a/client/src/utils/map/naverMap.ts
+++ b/client/src/utils/map/naverMap.ts
@@ -1,4 +1,5 @@
 import { Coordinate, getQueryMapRange } from './map';
+import footprint from '../../static/footprint.svg';
 
 export const createMap = ({ latitude, longitude }: Coordinate) => {
   return new naver.maps.Map('map', {
@@ -19,12 +20,13 @@ export const createMarker = (
     position: new naver.maps.LatLng(latitude, longitude),
     map,
     // 원하는 이미지로 마커 커스텀
-    // icon: {
-    //     url: pinImage,
-    //     size: new naver.maps.Size(50, 52),
-    //     origin: new naver.maps.Point(0, 0),
-    //     anchor: new naver.maps.Point(25, 26),
-    //   },
+    icon: {
+      content: `<img src=${footprint} width="25" height="25" alt="Create/Delete DropDown" />`,
+      //     url: pinImage,
+      //     size: new naver.maps.Size(50, 52),
+      //     origin: new naver.maps.Point(0, 0),
+      //     anchor: new naver.maps.Point(25, 26),
+    },
   });
 };
 


### PR DESCRIPTION
### Motivation :
- 재사용되는 코드가 꽤 길게 존재함
- 지도 영역이 변경될 때마다 바로바로 데이터를 요청하는 경우, 서버에 무수히 많은 데이터가 갈 수 있음
- 상수가 사용되고, 명확하지 않은 함수 이름에 대해 재정의가 필요

### Modifications:
- 지도 영역이 변경되는 경우, setTimeout으로 0.6초 후 서버에 데이터 요청
- 현재 위치를 불러오는 코드가 재사용되고, 너무 길어 custom hook으로 분리
- 사용하는 상수를 따로 파일로 분리

### Result:
- useCurrentLocation으로 현재 위치를 가져오는 코드 분리
- constants repository를 만들어 상수 분리
- 고차함수 사용 및 함수 renaming
- 필요없는 주석 삭제
- 지도를 움직이거나 줌레벨이 변하는 경우 0.6초 후 데이터 요청

close #96 