### PR TITLE
[fe/fix_home] Revert "fix: 좋아요 클릭시, stale한 board 데이터 업데이트"

### DIFF
--- a/client/src/pages/HomePage/HomePage.tsx
+++ b/client/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
 import user from '../../store/userAtom';
@@ -26,7 +26,6 @@ const makeBoarList = (boards: Board[]) => {
 };
 
 const HomePage = () => {
-  const querytClient = useQueryClient();
   const setUserData = useSetRecoilState(user);
   const navigate = useNavigate();
   const requestCount = 10000;
@@ -43,9 +42,6 @@ const HomePage = () => {
     () =>
       getBoardData(requestCount, '-1').then((response) => response.data.boards),
     {
-      onSuccess: () => {
-        querytClient.invalidateQueries('boards');
-      },
       onError: (error) => {
         if (
           error.response &&


### PR DESCRIPTION
### Motivation :
- board를 불러올 때마다 데이터를 업데이트하니 무한 업데이트 이슈 발생

### Modifications:
- revert patch

### Result:
- 정상 작동
