### PR TITLE
[fe/DmListPage] DmListPage UI 구조 생성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import LoginPage from './pages/LoginPage/LoginPage';
 import {
   BoardDetailPage,
   CommentPage,
+  DmListPage,
   FollowPage,
   HomePage,
   LoadingPage,
@@ -57,6 +58,7 @@ const App = () => {
             <Route path="/follow/:userName/:userId" element={<FollowPage />} />
             <Route path="/map" element={<MapPage />} />
             <Route path="/detail" element={<BoardDetailPage />} />
+            <Route path="/dmtest" element={<DmListPage />} />
           </Routes>
         </QueryClientProvider>
       </RecoilRoot>

--- a/client/src/components/DmListContainer/DmListContainer.tsx
+++ b/client/src/components/DmListContainer/DmListContainer.tsx
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from 'react';
+import DmListUnit from '../DmListUnit/DmListUnit';
+// import { useQuery } from 'react-query';
+// import axios, { AxiosError } from 'axios';
+// import { useRecoilValue } from 'recoil';
+// recoil
+// style
+import S from './DmListContainerStyles';
+// api
+// component
+// import FollowUnit from '../FollowUnit/FollowUnit';
+// type
+
+interface FollowerContainerProps {
+  userId: number;
+  userName: string;
+}
+
+// TODO 리엑트 쿼리 관련 코드를 분할하는 것이 좋을 수 있다.
+const DmListContainer = ({ userId, userName }: FollowerContainerProps) => {
+  // const followList = useQuery<FollowListData, AxiosError>('followList', () =>
+  //   getFollow(Number(userId), viewerId).then((res) => res.data),
+  // );
+
+  // if (followList.isLoading || followList.isIdle) {
+  //   return (
+  //     <S.Body>
+  //       <p>Loading...</p>
+  //     </S.Body>
+  //   );
+  // }
+
+  // if (followList.isError) {
+  //   return (
+  //     <S.Body>
+  //       <p>
+  //         {axios.isAxiosError(followList.error)
+  //           ? followList.error.message
+  //           : 'error'}
+  //       </p>
+  //     </S.Body>
+  //   );
+  // }
+
+  return (
+    <S.Body>
+      <S.UnitContainer>
+        <DmListUnit
+          targetId={22}
+          userName="test1"
+          userProfile=""
+          messageTime="2022-12-22T14:49:48.061Z"
+          messageCnt={11}
+          lastMessage="테스트입니다. 장문을 적으면 이렇게 줄이 가려집니다. 안녕하세요."
+        />
+        <DmListUnit
+          targetId={21}
+          userName="test2"
+          userProfile=""
+          messageTime="2022-12-15T17:01:00.830Z"
+          messageCnt={11}
+          lastMessage="테스트입니다."
+        />
+        <DmListUnit
+          targetId={20}
+          userName="test3"
+          userProfile=""
+          messageTime="2022-12-20T11:11:51.463Z"
+          messageCnt={11}
+          lastMessage="테스트입니다."
+        />
+      </S.UnitContainer>
+    </S.Body>
+  );
+};
+
+export default DmListContainer;

--- a/client/src/components/DmListContainer/DmListContainerStyles.tsx
+++ b/client/src/components/DmListContainer/DmListContainerStyles.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+const Body = styled.div`
+  width: 100vw;
+  height: calc(100vh - 10rem);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  padding: 1rem 0rem;
+
+  * {
+    font-family: 'SF-Pro';
+    font-style: normal;
+    font-weight: 400;
+  }
+`;
+
+const UnitContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+
+  width: 100%;
+  max-width: 35rem;
+
+  div:not(:last-of-type) {
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid ${(props) => props.theme.palette.border};
+  }
+`;
+
+export default { Body, UnitContainer };

--- a/client/src/components/DmListUnit/DmListUnit.tsx
+++ b/client/src/components/DmListUnit/DmListUnit.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from 'react';
+import ProfileIcon from '../ProfileIcon/ProfileIcon';
+// style
+import S from './DmListUnitStyles';
+// util
+import timeCalc from '../../utils/timeCalc';
+
+interface DmListUnitProps {
+  targetId: number;
+  userName: string;
+  userProfile: string;
+  messageTime: string;
+  messageCnt: number;
+  lastMessage: string;
+}
+
+const DmListUnit = ({
+  targetId,
+  userName,
+  userProfile,
+  messageTime,
+  messageCnt,
+  lastMessage,
+}: DmListUnitProps) => {
+  return (
+    <S.OuterContainer>
+      <ProfileIcon
+        targetId={targetId}
+        userName={userName}
+        userProfile={userProfile || '../../defaultProfile.svg'}
+      />
+      <S.InnerContainer type="button">
+        <S.Name>{userName}</S.Name>
+        <S.DmContentContainer>
+          <S.Message>{lastMessage}</S.Message>
+          <S.Time>{timeCalc(messageTime)}</S.Time>
+        </S.DmContentContainer>
+      </S.InnerContainer>
+    </S.OuterContainer>
+  );
+};
+
+export default DmListUnit;

--- a/client/src/components/DmListUnit/DmListUnitStyles.tsx
+++ b/client/src/components/DmListUnit/DmListUnitStyles.tsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+
+const OuterContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+  height: 3rem;
+  width: 80%;
+
+  * {
+    font-family: 'SF-Pro';
+    font-style: normal;
+    font-weight: 590;
+    font-size: 15px;
+    line-height: 18px;
+  }
+`;
+
+const InnerContainer = styled.button`
+  background-color: transparent;
+  cursor: pointer;
+  border: none;
+  width: 80%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const DmContentContainer = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Name = styled.p`
+  margin: 0px;
+  font-weight: 590;
+  font-size: 15px;
+  line-height: 18px;
+`;
+
+const Message = styled.p`
+  margin: 0px;
+  text-align: left;
+  width: 65%;
+  font-weight: 400;
+  font-size: 15px;
+  line-height: 18px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const Time = styled.p`
+  margin: 0px;
+  width: 25%;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 18px;
+
+  color: #7e7656;
+`;
+
+export default {
+  OuterContainer,
+  Name,
+  Message,
+  Time,
+  InnerContainer,
+  DmContentContainer,
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,9 @@
 html {
   font-size: 16px;
   height: 100vh;
+  -webkit-text-size-adjust: none;
+  -moz-text-size-adjust: none;
+  -ms-text-size-adjust: none;
 }
 
 body {

--- a/client/src/pages/DmListPage/DmListPage.tsx
+++ b/client/src/pages/DmListPage/DmListPage.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+// recoil
+import user from '../../store/userAtom';
+// component
+import NavBar from '../../components/NavBar/NavBar';
+import TopBar from '../../components/TopBar/TopBar';
+import DmListContainer from '../../components/DmListContainer/DmListContainer';
+
+const DmListPage = () => {
+  const navigation = useNavigate();
+
+  const { userId, userName } = useRecoilValue(user);
+
+  useEffect(() => {
+    if (!userName || !userId) navigation('/');
+  }, []);
+
+  return (
+    <>
+      <TopBar isBack={false} title="다이렉트 메시지" isCheck={false} />
+      <DmListContainer userId={Number(userId)} userName={userName} />
+      <NavBar />
+    </>
+  );
+};
+
+export default DmListPage;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -60,3 +60,8 @@ export const BoardDetailPage = Loadable({
   loader: () => import('./BoardDetailPage/BoardDetailPage'),
   loading: Loading,
 });
+
+export const DmListPage = Loadable({
+  loader: () => import('./DmListPage/DmListPage'),
+  loading: Loading,
+});


### PR DESCRIPTION
Motivation:
- dm 페이지에 들어갔을 때 dm을 했던 유저들에 대한 리스트를 보여주는 페이지가 필요하다.

Modifications:
- dm 페이지 관련 UI 생성
- 크게 Page, Container, Unit 으로 컴포넌트를 분리해서 생성

Result:
- /dmtest 링크에서 샘플 페이지 디자인을 확인할 수 있다.