### PR TITLE
[fe/fix-mobile-style] 모바일 환경에서 버튼 구조 변경

### DIFF
--- a/client/src/components/ProfileIcon/ProfileIcon.tsx
+++ b/client/src/components/ProfileIcon/ProfileIcon.tsx
@@ -16,7 +16,7 @@ const Button = styled.button<{ customLength: number }>`
   height: ${(props) => `${props.customLength}rem`};
   background-color: transparent;
   border: 0px;
-  padding: 0px;
+  padding: 1px;
   cursor: pointer;
 
   img {

--- a/client/src/components/UserInfoContainer/UserInfoContainerStyles.tsx
+++ b/client/src/components/UserInfoContainer/UserInfoContainerStyles.tsx
@@ -43,7 +43,7 @@ const Name = styled.p`
   line-height: 30px;
 
   margin-top: 0px;
-  margin: 0.5rem 0rem;
+  margin: 0.5rem 0rem 0.75rem 0rem;
 `;
 
 const InnerContainer = styled.div`
@@ -58,20 +58,17 @@ const CountSlot = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 0.25rem;
+
   button {
     font-size: 16px;
     padding: 0px;
+    margin: 0px;
+    color: #000000;
     background-color: transparent;
     border: none;
     cursor: pointer;
   }
-  p:first-child {
-    text-align: center;
-    margin: 0px;
-    font-weight: 590;
-    font-size: 14px;
-    line-height: 17px;
-  }
+
   p:last-child {
     text-align: center;
     margin: 0px;

--- a/client/src/pages/LoginPage/LoginPageStyles.tsx
+++ b/client/src/pages/LoginPage/LoginPageStyles.tsx
@@ -39,10 +39,16 @@ const CustomOauthButton = styled.button`
   justify-content: center;
   gap: 0.5rem;
   font-size: 1.1rem;
+  padding: 0px;
+  margin: 0px;
 
   img {
     width: 1.5rem;
     height: 1.5rem;
+  }
+
+  span {
+    color: #000000;
   }
 `;
 


### PR DESCRIPTION
Motivation:
- 모바일 환경에서 프로필 아이콘과 버튼 안의 p 태그가 이상한 현상이 있었다.

Modifications:
- 프로필 아이콘에 1px 씩 padding을 넣어주었다.
- 버튼 안의 글씨에게 직접 색을 부여했다.
- 버튼의 padding, margin을 제거해주었다.

Result:
- 실제 서버에서 확인을 해봐야 한다.