### PR TITLE
[fe/fix-mobile-style] 모바일 환경에서 버튼 구조 변경

### DIFF
--- a/client/src/components/UserInfoContainer/UserInfoContainerStyles.tsx
+++ b/client/src/components/UserInfoContainer/UserInfoContainerStyles.tsx
@@ -69,7 +69,7 @@ const CountSlot = styled.div`
     cursor: pointer;
   }
 
-  p:last-child {
+  p {
     text-align: center;
     margin: 0px;
     font-weight: 400;


### PR DESCRIPTION
Motivation:
- 모바일 환경에서 프로필 아이콘과 버튼 안의 p 태그가 이상한 현상이 있었다.

Modifications:
- 프로필 아이콘에 1px 씩 padding을 넣어주었다.
- 버튼 안의 글씨에게 직접 색을 부여했다.
- 버튼의 padding, margin을 제거해주었다.

Result:
- 실제 서버에서 확인을 해봐야 한다.