### PR TITLE
fix: 채팅 관련 버그 수정

### DIFF
--- a/server/api/src/dm/dm.service.ts
+++ b/server/api/src/dm/dm.service.ts
@@ -3,7 +3,7 @@ import { DMRoomRepository } from './dmroom.repository';
 import { DMRepository } from '@repository/dm.repository';
 import { GetMessageDto } from './dto/get-message.dto';
 import { UpdateLastSeenChatDto } from './dto/update-lastSeenChat.dto';
-import { pipe, map, toArray } from '@fxts/core';
+import { pipe, map, toArray, reverse } from '@fxts/core';
 
 @Injectable()
 export class DmService {
@@ -75,6 +75,7 @@ export class DmService {
         messages: pipe(
           messages,
           map((message) => message.toClient()),
+          reverse,
           toArray,
         ),
         count: cnt,
@@ -114,6 +115,7 @@ export class DmService {
           messages: pipe(
             messages,
             map((message) => message.toClient()),
+            reverse,
             toArray,
           ),
           count: cnt,

--- a/server/dao/schemas/dm.schema.ts
+++ b/server/dao/schemas/dm.schema.ts
@@ -12,7 +12,7 @@ export class DM extends Document {
   @Prop({ required: true })
   content: string;
 
-  @Prop({ default: new Date(), type: mongoose.Schema.Types.Date })
+  @Prop({ type: mongoose.Schema.Types.Date })
   createdAt: Date;
 
   toClient(): { id: string; sender: number; content: string; createdAt: Date } {


### PR DESCRIPTION
### Motivation :
채팅 시 발생하는 오류를 해결하기 위함

### Modifications:
1. 채팅 저장 시 createAt가 올바르게 저장되지 않는 오류 -> schema에서 default를 지워 해결
2. 채팅창에서 메세지가 역순으로 나타나는 오류 -> 서버에서 전달할 때 reverse해서 주는 것으로 해결

### Result:
1. 채팅 메세지 createAt 저장 오류 해결
2. 채팅창 메세지 올바른 순서로 노출